### PR TITLE
Improve secret management for upgraded template

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("composetemplate.android.library")
     id("composetemplate.android.hilt")
+    id("composetemplate.test")
 }
 
 android {

--- a/core/data/src/main/java/com/ytapps/composetemplate/core/data/IPreferencesManager.kt
+++ b/core/data/src/main/java/com/ytapps/composetemplate/core/data/IPreferencesManager.kt
@@ -3,37 +3,17 @@ package com.ytapps.composetemplate.core.data
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Interface for managing user preferences with DataStore.
- * Provides both synchronous (cached) and asynchronous access patterns.
+ * Interface for managing non-sensitive user preferences with DataStore.
  */
-@Suppress("TooManyFunctions")
 interface IPreferencesManager {
-    // Synchronous getters (for interceptor compatibility - uses cached values)
-    fun getAccessToken(): String?
-
-    fun getRefreshToken(): String?
-
-    fun getTokenType(): String?
-
     fun getUUID(): String?
 
     fun hasUser(): Boolean
-
-    // Async setters (DataStore operations)
-    suspend fun setAccessToken(accessToken: String)
-
-    suspend fun setRefreshToken(refreshToken: String)
-
-    suspend fun setTokenType(tokenType: String)
 
     suspend fun setUUID(uuid: String)
 
     suspend fun clear()
 
-    // Flow-based reactive access
-    val accessTokenFlow: StateFlow<String?>
-    val refreshTokenFlow: StateFlow<String?>
-    val tokenTypeFlow: StateFlow<String?>
     val uuidFlow: StateFlow<String?>
     val isDarkModeFlow: StateFlow<Boolean>
     val languageCodeFlow: StateFlow<String?>

--- a/core/data/src/main/java/com/ytapps/composetemplate/core/data/PreferencesManager.kt
+++ b/core/data/src/main/java/com/ytapps/composetemplate/core/data/PreferencesManager.kt
@@ -19,13 +19,11 @@ import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 import javax.inject.Singleton
 
-// Extension to create DataStore instance
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
     name = "user_preferences",
 )
 
 @Singleton
-@Suppress("TooManyFunctions")
 class PreferencesManager
     @Inject
     constructor(
@@ -34,22 +32,6 @@ class PreferencesManager
     ) : IPreferencesManager {
         private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
         private val dataStore = appContext.dataStore
-
-        // Cached StateFlows for synchronous access
-        private val cachedAccessToken: StateFlow<String?> =
-            dataStore.data
-                .map { preferences -> preferences[Keys.ACCESS_TOKEN] }
-                .stateIn(scope, SharingStarted.Eagerly, null)
-
-        private val cachedRefreshToken: StateFlow<String?> =
-            dataStore.data
-                .map { preferences -> preferences[Keys.REFRESH_TOKEN] }
-                .stateIn(scope, SharingStarted.Eagerly, null)
-
-        private val cachedTokenType: StateFlow<String?> =
-            dataStore.data
-                .map { preferences -> preferences[Keys.TOKEN_TYPE] }
-                .stateIn(scope, SharingStarted.Eagerly, null)
 
         private val cachedUUID: StateFlow<String?> =
             dataStore.data
@@ -71,35 +53,9 @@ class PreferencesManager
                 .map { preferences -> preferences[Keys.IS_ONBOARDING_COMPLETED] ?: false }
                 .stateIn(scope, SharingStarted.Eagerly, false)
 
-        // Synchronous getters (use cached StateFlow values)
-        override fun getAccessToken(): String? = cachedAccessToken.value
-
-        override fun getRefreshToken(): String? = cachedRefreshToken.value
-
-        override fun getTokenType(): String? = cachedTokenType.value
-
         override fun getUUID(): String? = cachedUUID.value
 
         override fun hasUser(): Boolean = cachedUUID.value != null
-
-        // Async setters (DataStore operations)
-        override suspend fun setAccessToken(accessToken: String) {
-            dataStore.edit { preferences ->
-                preferences[Keys.ACCESS_TOKEN] = accessToken
-            }
-        }
-
-        override suspend fun setRefreshToken(refreshToken: String) {
-            dataStore.edit { preferences ->
-                preferences[Keys.REFRESH_TOKEN] = refreshToken
-            }
-        }
-
-        override suspend fun setTokenType(tokenType: String) {
-            dataStore.edit { preferences ->
-                preferences[Keys.TOKEN_TYPE] = tokenType
-            }
-        }
 
         override suspend fun setUUID(uuid: String) {
             dataStore.edit { preferences ->
@@ -131,13 +87,6 @@ class PreferencesManager
             }
         }
 
-        // Flow-based reactive access (delegates to cached StateFlows)
-        override val accessTokenFlow: StateFlow<String?> get() = cachedAccessToken
-
-        override val refreshTokenFlow: StateFlow<String?> get() = cachedRefreshToken
-
-        override val tokenTypeFlow: StateFlow<String?> get() = cachedTokenType
-
         override val uuidFlow: StateFlow<String?> get() = cachedUUID
 
         override val isDarkModeFlow: StateFlow<Boolean> get() = cachedIsDarkMode
@@ -147,9 +96,6 @@ class PreferencesManager
         override val isOnboardingCompletedFlow: StateFlow<Boolean> get() = cachedIsOnboardingCompleted
 
         private object Keys {
-            val ACCESS_TOKEN = stringPreferencesKey("key_access_token")
-            val REFRESH_TOKEN = stringPreferencesKey("key_refresh_token")
-            val TOKEN_TYPE = stringPreferencesKey("key_token_type")
             val UUID = stringPreferencesKey("key_uuid")
             val IS_DARK_MODE = booleanPreferencesKey("key_is_dark_mode")
             val LANGUAGE_CODE = stringPreferencesKey("key_language_code")

--- a/core/data/src/main/java/com/ytapps/composetemplate/core/data/di/SecurityModule.kt
+++ b/core/data/src/main/java/com/ytapps/composetemplate/core/data/di/SecurityModule.kt
@@ -1,0 +1,15 @@
+package com.ytapps.composetemplate.core.data.di
+
+import com.ytapps.composetemplate.core.data.security.KeystoreTokenStore
+import com.ytapps.composetemplate.core.data.security.TokenStore
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class SecurityModule {
+    @Binds
+    abstract fun bindTokenStore(tokenStore: KeystoreTokenStore): TokenStore
+}

--- a/core/data/src/main/java/com/ytapps/composetemplate/core/data/security/AuthTokens.kt
+++ b/core/data/src/main/java/com/ytapps/composetemplate/core/data/security/AuthTokens.kt
@@ -1,0 +1,11 @@
+package com.ytapps.composetemplate.core.data.security
+
+data class AuthTokens(
+    val accessToken: String,
+    val refreshToken: String,
+    val tokenType: String = DEFAULT_TOKEN_TYPE,
+) {
+    companion object {
+        const val DEFAULT_TOKEN_TYPE = "Bearer"
+    }
+}

--- a/core/data/src/main/java/com/ytapps/composetemplate/core/data/security/KeystoreTokenStore.kt
+++ b/core/data/src/main/java/com/ytapps/composetemplate/core/data/security/KeystoreTokenStore.kt
@@ -1,0 +1,163 @@
+package com.ytapps.composetemplate.core.data.security
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.ytapps.composetemplate.core.common.IoDispatcher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.withContext
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.tokenDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "auth_tokens",
+)
+
+/**
+ * TokenStore implementation backed by DataStore and Android Keystore.
+ *
+ * Token values are encrypted with AES/GCM before being written to DataStore. This
+ * avoids deprecated EncryptedSharedPreferences/security-crypto APIs while keeping
+ * synchronous in-memory reads available for OkHttp interceptors.
+ */
+@Singleton
+internal class KeystoreTokenStore
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+        @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    ) : TokenStore {
+        private val dataStore = context.tokenDataStore
+        private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+        private val cryptoLock = Any()
+
+        private val cachedTokens: StateFlow<AuthTokens?> =
+            dataStore.data
+                .map { preferences -> preferences.toAuthTokensOrNull() }
+                .stateIn(scope, SharingStarted.Eagerly, null)
+
+        override fun getTokens(): AuthTokens? = cachedTokens.value
+
+        override suspend fun saveTokens(tokens: AuthTokens) {
+            val encryptedAccessToken = encrypt(tokens.accessToken)
+            val encryptedRefreshToken = encrypt(tokens.refreshToken)
+
+            dataStore.edit { preferences ->
+                preferences[Keys.ACCESS_TOKEN] = encryptedAccessToken
+                preferences[Keys.REFRESH_TOKEN] = encryptedRefreshToken
+                preferences[Keys.TOKEN_TYPE] = tokens.tokenType
+            }
+        }
+
+        override suspend fun clear() {
+            dataStore.edit { preferences ->
+                preferences.remove(Keys.ACCESS_TOKEN)
+                preferences.remove(Keys.REFRESH_TOKEN)
+                preferences.remove(Keys.TOKEN_TYPE)
+            }
+        }
+
+        override val tokensFlow: Flow<AuthTokens?> = cachedTokens
+
+        private suspend fun Preferences.toAuthTokensOrNull(): AuthTokens? =
+            withContext(ioDispatcher) {
+                val encryptedAccessToken = this@toAuthTokensOrNull[Keys.ACCESS_TOKEN]
+                val encryptedRefreshToken = this@toAuthTokensOrNull[Keys.REFRESH_TOKEN]
+
+                if (encryptedAccessToken.isNullOrBlank() || encryptedRefreshToken.isNullOrBlank()) {
+                    return@withContext null
+                }
+
+                runCatching {
+                    AuthTokens(
+                        accessToken = decrypt(encryptedAccessToken),
+                        refreshToken = decrypt(encryptedRefreshToken),
+                        tokenType = this@toAuthTokensOrNull[Keys.TOKEN_TYPE] ?: AuthTokens.DEFAULT_TOKEN_TYPE,
+                    )
+                }.getOrNull()
+            }
+
+        private suspend fun encrypt(value: String): String =
+            withContext(ioDispatcher) {
+                synchronized(cryptoLock) {
+                    val cipher = Cipher.getInstance(TRANSFORMATION)
+                    cipher.init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+                    val encrypted = cipher.doFinal(value.toByteArray(Charsets.UTF_8))
+                    val iv = cipher.iv
+
+                    "${iv.base64()}$ENCRYPTED_VALUE_SEPARATOR${encrypted.base64()}"
+                }
+            }
+
+        private fun decrypt(value: String): String =
+            synchronized(cryptoLock) {
+                val parts = value.split(ENCRYPTED_VALUE_SEPARATOR)
+                require(parts.size == ENCRYPTED_VALUE_PARTS)
+
+                val iv = Base64.decode(parts[0], Base64.NO_WRAP)
+                val encrypted = Base64.decode(parts[1], Base64.NO_WRAP)
+                val cipher = Cipher.getInstance(TRANSFORMATION)
+                cipher.init(Cipher.DECRYPT_MODE, getOrCreateSecretKey(), GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv))
+
+                String(cipher.doFinal(encrypted), Charsets.UTF_8)
+            }
+
+        private fun getOrCreateSecretKey(): SecretKey {
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+            val existingKey = keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry
+            if (existingKey != null) {
+                return existingKey.secretKey
+            }
+
+            val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+            val keySpec =
+                KeyGenParameterSpec
+                    .Builder(
+                        KEY_ALIAS,
+                        KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                    ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setKeySize(KEY_SIZE_BITS)
+                    .build()
+
+            keyGenerator.init(keySpec)
+            return keyGenerator.generateKey()
+        }
+
+        private fun ByteArray.base64(): String = Base64.encodeToString(this, Base64.NO_WRAP)
+
+        private object Keys {
+            val ACCESS_TOKEN = stringPreferencesKey("key_access_token")
+            val REFRESH_TOKEN = stringPreferencesKey("key_refresh_token")
+            val TOKEN_TYPE = stringPreferencesKey("key_token_type")
+        }
+
+        private companion object {
+            const val ANDROID_KEYSTORE = "AndroidKeyStore"
+            const val KEY_ALIAS = "com.ytapps.composetemplate.auth_tokens"
+            const val TRANSFORMATION = "AES/GCM/NoPadding"
+            const val GCM_TAG_LENGTH_BITS = 128
+            const val KEY_SIZE_BITS = 256
+            const val ENCRYPTED_VALUE_SEPARATOR = ":"
+            const val ENCRYPTED_VALUE_PARTS = 2
+        }
+    }

--- a/core/data/src/main/java/com/ytapps/composetemplate/core/data/security/SessionManager.kt
+++ b/core/data/src/main/java/com/ytapps/composetemplate/core/data/security/SessionManager.kt
@@ -1,0 +1,25 @@
+package com.ytapps.composetemplate.core.data.security
+
+import com.ytapps.composetemplate.core.data.IPreferencesManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Clears all local session state in one place.
+ *
+ * Token storage is intentionally separate from regular preferences, so callers
+ * should use this class for logout/session reset instead of clearing only user
+ * preferences.
+ */
+@Singleton
+class SessionManager
+    @Inject
+    constructor(
+        private val preferencesManager: IPreferencesManager,
+        private val tokenStore: TokenStore,
+    ) {
+        suspend fun clearSession() {
+            tokenStore.clear()
+            preferencesManager.clear()
+        }
+    }

--- a/core/data/src/main/java/com/ytapps/composetemplate/core/data/security/TokenStore.kt
+++ b/core/data/src/main/java/com/ytapps/composetemplate/core/data/security/TokenStore.kt
@@ -1,0 +1,25 @@
+package com.ytapps.composetemplate.core.data.security
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Stores authentication tokens separately from regular user preferences.
+ *
+ * Implementations must avoid deprecated security APIs and should persist tokens
+ * encrypted at rest with Android Keystore-backed keys.
+ */
+interface TokenStore {
+    fun getTokens(): AuthTokens?
+
+    fun getAccessToken(): String? = getTokens()?.accessToken
+
+    fun getRefreshToken(): String? = getTokens()?.refreshToken
+
+    fun getTokenType(): String = getTokens()?.tokenType ?: AuthTokens.DEFAULT_TOKEN_TYPE
+
+    suspend fun saveTokens(tokens: AuthTokens)
+
+    suspend fun clear()
+
+    val tokensFlow: Flow<AuthTokens?>
+}

--- a/core/data/src/test/java/com/ytapps/composetemplate/core/data/security/SessionManagerTest.kt
+++ b/core/data/src/test/java/com/ytapps/composetemplate/core/data/security/SessionManagerTest.kt
@@ -1,0 +1,30 @@
+package com.ytapps.composetemplate.core.data.security
+
+import com.ytapps.composetemplate.core.data.IPreferencesManager
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class SessionManagerTest {
+    private lateinit var preferencesManager: IPreferencesManager
+    private lateinit var tokenStore: TokenStore
+    private lateinit var sessionManager: SessionManager
+
+    @Before
+    fun setup() {
+        preferencesManager = mockk(relaxed = true)
+        tokenStore = mockk(relaxed = true)
+        sessionManager = SessionManager(preferencesManager, tokenStore)
+    }
+
+    @Test
+    fun `clearSession clears tokens and preferences`() =
+        runTest {
+            sessionManager.clearSession()
+
+            coVerify { tokenStore.clear() }
+            coVerify { preferencesManager.clear() }
+        }
+}

--- a/core/data/src/test/java/com/ytapps/composetemplate/core/data/security/TokenStoreTest.kt
+++ b/core/data/src/test/java/com/ytapps/composetemplate/core/data/security/TokenStoreTest.kt
@@ -1,0 +1,77 @@
+package com.ytapps.composetemplate.core.data.security
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class TokenStoreContractTest {
+    private lateinit var tokenStore: FakeTokenStore
+
+    @Before
+    fun setup() {
+        tokenStore = FakeTokenStore()
+    }
+
+    @Test
+    fun `saveTokens updates tokensFlow atomically`() =
+        runTest {
+            val tokens =
+                AuthTokens(
+                    accessToken = "test_access_token_123",
+                    refreshToken = "test_refresh_token_456",
+                    tokenType = "Bearer",
+                )
+
+            tokenStore.saveTokens(tokens)
+
+            assertThat(tokenStore.tokensFlow.first()).isEqualTo(tokens)
+            assertThat(tokenStore.getTokens()).isEqualTo(tokens)
+            assertThat(tokenStore.getAccessToken()).isEqualTo(tokens.accessToken)
+            assertThat(tokenStore.getRefreshToken()).isEqualTo(tokens.refreshToken)
+            assertThat(tokenStore.getTokenType()).isEqualTo(tokens.tokenType)
+        }
+
+    @Test
+    fun `getTokenType returns Bearer by default`() {
+        assertThat(tokenStore.getTokenType()).isEqualTo(AuthTokens.DEFAULT_TOKEN_TYPE)
+    }
+
+    @Test
+    fun `clear removes all tokens`() =
+        runTest {
+            tokenStore.saveTokens(
+                AuthTokens(
+                    accessToken = "token",
+                    refreshToken = "refresh",
+                    tokenType = "Bearer",
+                ),
+            )
+
+            tokenStore.clear()
+
+            assertThat(tokenStore.getTokens()).isNull()
+            assertThat(tokenStore.getAccessToken()).isNull()
+            assertThat(tokenStore.getRefreshToken()).isNull()
+            assertThat(tokenStore.getTokenType()).isEqualTo(AuthTokens.DEFAULT_TOKEN_TYPE)
+        }
+}
+
+private class FakeTokenStore : TokenStore {
+    private val tokens = MutableStateFlow<AuthTokens?>(null)
+
+    override fun getTokens(): AuthTokens? = tokens.value
+
+    override suspend fun saveTokens(tokens: AuthTokens) {
+        this.tokens.value = tokens
+    }
+
+    override suspend fun clear() {
+        tokens.value = null
+    }
+
+    override val tokensFlow: Flow<AuthTokens?> = tokens
+}

--- a/core/network/src/main/java/com/ytapps/composetemplate/core/network/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/ytapps/composetemplate/core/network/AuthInterceptor.kt
@@ -1,6 +1,6 @@
 package com.ytapps.composetemplate.core.network
 
-import com.ytapps.composetemplate.core.data.IPreferencesManager
+import com.ytapps.composetemplate.core.data.security.TokenStore
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
@@ -12,15 +12,13 @@ import javax.inject.Inject
 internal class AuthInterceptor
     @Inject
     constructor(
-        private val prefs: IPreferencesManager,
+        private val tokenStore: TokenStore,
     ) : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
             val originalRequest = chain.request()
 
-            val tokenType = prefs.getTokenType()
-            val accessToken = prefs.getAccessToken()
+            val accessToken = tokenStore.getAccessToken()
 
-            // If no token available, proceed without auth header
             if (accessToken.isNullOrEmpty()) {
                 return chain.proceed(originalRequest)
             }
@@ -28,7 +26,7 @@ internal class AuthInterceptor
             val authenticatedRequest =
                 originalRequest
                     .newBuilder()
-                    .header(HEADER_AUTHORIZATION, "$tokenType $accessToken")
+                    .header(HEADER_AUTHORIZATION, "${tokenStore.getTokenType()} $accessToken")
                     .build()
 
             return chain.proceed(authenticatedRequest)

--- a/core/network/src/main/java/com/ytapps/composetemplate/core/network/ITokenRefresher.kt
+++ b/core/network/src/main/java/com/ytapps/composetemplate/core/network/ITokenRefresher.kt
@@ -1,10 +1,14 @@
 package com.ytapps.composetemplate.core.network
 
 import com.ytapps.composetemplate.core.common.Result
+import com.ytapps.composetemplate.core.data.security.AuthTokens
 
 /**
- * Interface definition for token refreshing mechanism
+ * Interface definition for token refreshing mechanism.
+ *
+ * Implementations should return the complete refreshed token set so callers can
+ * persist access and refresh tokens atomically.
  */
 interface ITokenRefresher {
-    suspend fun refreshToken(): Result<String>
+    suspend fun refreshTokens(): Result<AuthTokens>
 }

--- a/core/network/src/main/java/com/ytapps/composetemplate/core/network/TokenAuthenticator.kt
+++ b/core/network/src/main/java/com/ytapps/composetemplate/core/network/TokenAuthenticator.kt
@@ -1,7 +1,8 @@
 package com.ytapps.composetemplate.core.network
 
 import com.ytapps.composetemplate.core.common.getOrNull
-import com.ytapps.composetemplate.core.data.IPreferencesManager
+import com.ytapps.composetemplate.core.data.security.AuthTokens
+import com.ytapps.composetemplate.core.data.security.TokenStore
 import dagger.Lazy
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
@@ -29,7 +30,7 @@ import javax.inject.Singleton
 internal class TokenAuthenticator
     @Inject
     constructor(
-        private val prefs: IPreferencesManager,
+        private val tokenStore: TokenStore,
         private val tokenRefresher: Lazy<ITokenRefresher>,
     ) : Authenticator {
         private val lock = Any()
@@ -38,42 +39,37 @@ internal class TokenAuthenticator
             route: Route?,
             response: Response,
         ): Request? {
-            // Don't retry if we've already tried multiple times
             if (responseCount(response) >= MAX_RETRY_COUNT) {
                 return null
             }
 
-            val currentToken = prefs.getAccessToken()
+            val currentToken = tokenStore.getAccessToken()
 
             synchronized(lock) {
-                // Check if token was already refreshed by another thread
-                val latestToken = prefs.getAccessToken()
+                val latestToken = tokenStore.getAccessToken()
 
                 if (latestToken != currentToken && !latestToken.isNullOrEmpty()) {
-                    // Token was refreshed by another thread, retry with new token
                     return buildRequestWithToken(response.request, latestToken)
                 }
 
-                // Refresh the token
-                val newToken = refreshToken()
+                val refreshedTokens = refreshTokens()
 
-                return if (!newToken.isNullOrEmpty()) {
-                    buildRequestWithToken(response.request, newToken)
+                return if (refreshedTokens != null) {
+                    buildRequestWithToken(response.request, refreshedTokens.accessToken)
                 } else {
-                    // Token refresh failed, don't retry
                     null
                 }
             }
         }
 
-        private fun refreshToken(): String? =
+        private fun refreshTokens(): AuthTokens? =
             try {
-                // Note: runBlocking is acceptable here because:
-                // 1. Authenticator.authenticate() is called on OkHttp's dispatcher thread, not the main thread
-                // 2. The token refresh is a blocking operation by nature (we need the token before proceeding)
-                // 3. This is the standard pattern for OkHttp Authenticator with suspend functions
                 runBlocking {
-                    tokenRefresher.get().refreshToken().getOrNull()
+                    val tokens = tokenRefresher.get().refreshTokens().getOrNull()
+                    if (tokens != null) {
+                        tokenStore.saveTokens(tokens)
+                    }
+                    tokens
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Token refresh failed")
@@ -83,13 +79,11 @@ internal class TokenAuthenticator
         private fun buildRequestWithToken(
             request: Request,
             token: String,
-        ): Request {
-            val tokenType = prefs.getTokenType() ?: "Bearer"
-            return request
+        ): Request =
+            request
                 .newBuilder()
-                .header(HEADER_AUTHORIZATION, "$tokenType $token")
+                .header(HEADER_AUTHORIZATION, "${tokenStore.getTokenType()} $token")
                 .build()
-        }
 
         private fun responseCount(response: Response): Int {
             var count = 1

--- a/core/network/src/main/java/com/ytapps/composetemplate/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/ytapps/composetemplate/core/network/di/NetworkModule.kt
@@ -1,7 +1,7 @@
 package com.ytapps.composetemplate.core.network.di
 
 import com.ytapps.composetemplate.core.network.AuthInterceptor
-import com.ytapps.composetemplate.core.network.BuildConfig
+import com.ytapps.composetemplate.core.network.TokenAuthenticator
 import com.ytapps.composetemplate.core.secrets.SecretManager
 import dagger.Module
 import dagger.Provides
@@ -18,20 +18,31 @@ import javax.inject.Singleton
 internal object NetworkModule {
     @Provides
     @Singleton
-    fun provideOkHttpClient(authInterceptor: AuthInterceptor): OkHttpClient =
+    fun provideLoggingInterceptor(): HttpLoggingInterceptor =
+        HttpLoggingInterceptor().apply {
+            redactHeader(HEADER_AUTHORIZATION)
+            redactHeader(HEADER_COOKIE)
+            redactHeader(HEADER_SET_COOKIE)
+            redactHeader(HEADER_API_KEY)
+            redactHeader(HEADER_AUTH_TOKEN)
+            // Keep network logging disabled by default in the shared network module.
+            // Apps can replace this binding if they want opt-in debug logging.
+            level = HttpLoggingInterceptor.Level.NONE
+        }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(
+        authInterceptor: AuthInterceptor,
+        tokenAuthenticator: TokenAuthenticator,
+        loggingInterceptor: HttpLoggingInterceptor,
+    ): OkHttpClient =
         OkHttpClient
             .Builder()
             .addInterceptor(authInterceptor)
-            .addInterceptor(
-                HttpLoggingInterceptor().apply {
-                    level =
-                        if (BuildConfig.DEBUG) {
-                            HttpLoggingInterceptor.Level.BODY
-                        } else {
-                            HttpLoggingInterceptor.Level.NONE
-                        }
-                },
-            ).build()
+            .addInterceptor(loggingInterceptor)
+            .authenticator(tokenAuthenticator)
+            .build()
 
     @Provides
     @Singleton
@@ -42,4 +53,10 @@ internal object NetworkModule {
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
+
+    private const val HEADER_AUTHORIZATION = "Authorization"
+    private const val HEADER_COOKIE = "Cookie"
+    private const val HEADER_SET_COOKIE = "Set-Cookie"
+    private const val HEADER_API_KEY = "X-Api-Key"
+    private const val HEADER_AUTH_TOKEN = "X-Auth-Token"
 }

--- a/feature/auth/data/src/main/java/com/ytapps/composetemplate/feature/auth/data/AuthRepository.kt
+++ b/feature/auth/data/src/main/java/com/ytapps/composetemplate/feature/auth/data/AuthRepository.kt
@@ -3,10 +3,10 @@ package com.ytapps.composetemplate.feature.auth.data
 import com.ytapps.composetemplate.core.common.Result
 import com.ytapps.composetemplate.core.common.map
 import com.ytapps.composetemplate.core.data.IPreferencesManager
+import com.ytapps.composetemplate.core.data.security.AuthTokens
+import com.ytapps.composetemplate.core.data.security.TokenStore
 import com.ytapps.composetemplate.core.network.BaseRepository
 import com.ytapps.composetemplate.feature.auth.data.model.AuthRequestModel
-import com.ytapps.composetemplate.feature.auth.data.model.RefreshTokenRequestModel
-import com.ytapps.composetemplate.feature.auth.data.remote.AuthService
 import com.ytapps.composetemplate.feature.auth.domain.IAuthRepository
 import com.ytapps.composetemplate.feature.auth.domain.model.AuthModel
 import javax.inject.Inject
@@ -16,6 +16,7 @@ internal class AuthRepository
     constructor(
         private val authService: AuthService,
         private val prefs: IPreferencesManager,
+        private val tokenStore: TokenStore,
     ) : BaseRepository(),
         IAuthRepository {
         override fun hasUser(): Boolean = prefs.hasUser()
@@ -32,9 +33,13 @@ internal class AuthRepository
                         expiresIn = "99999",
                         tokenType = "Bearer",
                     )
-                prefs.setAccessToken(authModel.accessToken)
-                prefs.setRefreshToken(authModel.refreshToken)
-                prefs.setTokenType(authModel.tokenType)
+                tokenStore.saveTokens(
+                    AuthTokens(
+                        accessToken = authModel.accessToken,
+                        refreshToken = authModel.refreshToken,
+                        tokenType = authModel.tokenType,
+                    ),
+                )
                 prefs.setUUID("admin-uuid")
                 return Result.Success(authModel)
             }
@@ -59,24 +64,19 @@ internal class AuthRepository
                 }
             if (result is Result.Success) {
                 val data = result.data
-                prefs.setAccessToken(data.accessToken)
-                prefs.setRefreshToken(data.refreshToken)
-                prefs.setTokenType(data.tokenType)
+                tokenStore.saveTokens(
+                    AuthTokens(
+                        accessToken = data.accessToken,
+                        refreshToken = data.refreshToken,
+                        tokenType = data.tokenType,
+                    ),
+                )
             }
             return result
         }
 
-        override suspend fun refreshToken(): Result<String> {
-            val currentRefreshToken =
-                prefs.getRefreshToken()
-                    ?: return Result.Error("No refresh token available")
-
-            return safeCall {
-                authService.refreshToken(RefreshTokenRequestModel(currentRefreshToken))
-            }.map { response ->
-                prefs.setAccessToken(response.accessToken)
-                prefs.setRefreshToken(response.refreshToken)
-                response.accessToken
-            }
-        }
+        override suspend fun refreshTokens(): Result<AuthTokens> =
+            Result.Error(
+                message = "Refresh token endpoint is not implemented. Replace this template implementation with your API call.",
+            )
     }

--- a/feature/auth/data/src/main/java/com/ytapps/composetemplate/feature/auth/data/AuthRepository.kt
+++ b/feature/auth/data/src/main/java/com/ytapps/composetemplate/feature/auth/data/AuthRepository.kt
@@ -7,6 +7,7 @@ import com.ytapps.composetemplate.core.data.security.AuthTokens
 import com.ytapps.composetemplate.core.data.security.TokenStore
 import com.ytapps.composetemplate.core.network.BaseRepository
 import com.ytapps.composetemplate.feature.auth.data.model.AuthRequestModel
+import com.ytapps.composetemplate.feature.auth.data.remote.AuthService
 import com.ytapps.composetemplate.feature.auth.domain.IAuthRepository
 import com.ytapps.composetemplate.feature.auth.domain.model.AuthModel
 import javax.inject.Inject

--- a/feature/auth/data/src/test/java/com/ytapps/composetemplate/feature/auth/data/repository/AuthRepositoryTest.kt
+++ b/feature/auth/data/src/test/java/com/ytapps/composetemplate/feature/auth/data/repository/AuthRepositoryTest.kt
@@ -3,6 +3,8 @@ package com.ytapps.composetemplate.feature.auth.data.repository
 import com.google.common.truth.Truth
 import com.ytapps.composetemplate.core.common.Result
 import com.ytapps.composetemplate.core.data.IPreferencesManager
+import com.ytapps.composetemplate.core.data.security.AuthTokens
+import com.ytapps.composetemplate.core.data.security.TokenStore
 import com.ytapps.composetemplate.feature.auth.data.AuthRepository
 import com.ytapps.composetemplate.feature.auth.data.model.AuthRequestModel
 import com.ytapps.composetemplate.feature.auth.data.model.AuthResponseModel
@@ -22,40 +24,36 @@ internal class AuthRepositoryTest {
     private lateinit var authRepository: IAuthRepository
     private lateinit var authService: AuthService
     private lateinit var preferencesManager: IPreferencesManager
+    private lateinit var tokenStore: TokenStore
 
     @Before
     fun setUp() {
         authService = mockk<AuthService>()
         preferencesManager = mockk<IPreferencesManager>(relaxed = true)
-        authRepository = AuthRepository(authService, preferencesManager)
+        tokenStore = mockk<TokenStore>(relaxed = true)
+        authRepository = AuthRepository(authService, preferencesManager, tokenStore)
     }
 
     @Test
     fun `given signed user when hasUser() then return true`() {
-        // Given
         every { preferencesManager.hasUser() } returns true
 
-        // When
         val result = authRepository.hasUser()
 
-        // Then
         Truth.assertThat(result).isTrue()
     }
 
     @Test
     fun `given has not signed user when hasUser() then return false`() {
-        // Given
         every { preferencesManager.hasUser() } returns false
 
-        // When
         val result = authRepository.hasUser()
 
-        // Then
         Truth.assertThat(result).isFalse()
     }
 
     @Test
-    fun `given valid authRequestModel when login() then verify setAccessToken called`() =
+    fun `given valid authRequestModel when login then verify tokens are stored atomically`() =
         runTest {
             val authRequestModel =
                 AuthRequestModel(
@@ -74,25 +72,37 @@ internal class AuthRepositoryTest {
             val result = authRepository.login("email", "password")
 
             Truth.assertThat(result).isInstanceOf(Result.Success::class.java)
-            coVerify { preferencesManager.setAccessToken("token") }
-            coVerify { preferencesManager.setRefreshToken("refresh") }
-            coVerify { preferencesManager.setTokenType("Bearer") }
+            coVerify {
+                tokenStore.saveTokens(
+                    AuthTokens(
+                        accessToken = "token",
+                        refreshToken = "refresh",
+                        tokenType = "Bearer",
+                    ),
+                )
+            }
         }
 
     @Test
-    fun `given admin admin credentials when login then verify setUUID called`() =
+    fun `given admin admin credentials when login then verify session is created`() =
         runTest {
             val result = authRepository.login("admin", "admin")
 
             Truth.assertThat(result).isInstanceOf(Result.Success::class.java)
             coVerify { preferencesManager.setUUID("admin-uuid") }
-            coVerify { preferencesManager.setAccessToken("admin-token") }
-            coVerify { preferencesManager.setRefreshToken("admin-refresh") }
-            coVerify { preferencesManager.setTokenType("Bearer") }
+            coVerify {
+                tokenStore.saveTokens(
+                    AuthTokens(
+                        accessToken = "admin-token",
+                        refreshToken = "admin-refresh",
+                        tokenType = "Bearer",
+                    ),
+                )
+            }
         }
 
     @Test
-    fun `given invalid authRequestModel when login() then verify setAccessToken not called`() =
+    fun `given invalid authRequestModel when login then verify tokens are not stored`() =
         runTest {
             val authRequestModel =
                 AuthRequestModel(
@@ -108,6 +118,6 @@ internal class AuthRepositoryTest {
             val result = authRepository.login("email", "password")
 
             Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
-            coVerify(exactly = 0) { preferencesManager.setAccessToken(any()) }
+            coVerify(exactly = 0) { tokenStore.saveTokens(any()) }
         }
 }


### PR DESCRIPTION
## Summary
- Move access/refresh token handling out of regular DataStore preferences into a dedicated `TokenStore` abstraction aligned with the upgraded multi-module structure
- Add a Keystore-backed `KeystoreTokenStore` implementation that encrypts token values before storing them in DataStore
- Update network auth interceptor/authenticator and auth repository to use `TokenStore`
- Disable OkHttp logging by default and redact sensitive headers
- Add `SessionManager` for clearing token storage and non-sensitive preferences together
- Add/update contract tests for token/session handling and auth token persistence

## Notes
- `IPreferencesManager` now manages non-sensitive preferences only.
- Refresh token handling remains template-owned: apps should replace `refreshTokens()` with their real API implementation.
- Deprecated `EncryptedSharedPreferences` / `androidx.security-crypto` APIs are not used.

## Testing
- Not run locally in this environment.