### PR TITLE
Add GitHub Pages documentation wiki

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+      - name: Build site
+        run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/architecture/authentication-token-flow.md
+++ b/docs/architecture/authentication-token-flow.md
@@ -1,0 +1,24 @@
+# Authentication and Token Flow
+
+Authentication is handled through clear contracts between the network layer and the auth feature.
+
+## Main pieces
+
+- `AuthInterceptor`
+- `TokenAuthenticator`
+- `ITokenRefresher`
+- Auth repository
+- Token/session abstractions
+
+## Notes
+
+`AuthInterceptor` adds access tokens to requests. `TokenAuthenticator` handles 401 responses and delegates refresh work through `ITokenRefresher`.
+
+The template provides refresh infrastructure; the generated app must implement its real backend refresh endpoint.
+
+## Checklist
+
+- [ ] Token injection is handled in one place.
+- [ ] 401 refresh is handled by the authenticator.
+- [ ] Tokens are not logged.
+- [ ] Sensitive headers are redacted.

--- a/docs/architecture/clean-architecture.md
+++ b/docs/architecture/clean-architecture.md
@@ -1,0 +1,28 @@
+# Clean Architecture
+
+ComposeTemplate applies Clean Architecture through Gradle module boundaries, not only through package names.
+
+## Dependency rule
+
+```text
+Data can know Domain.
+Presentation can know Domain.
+Domain should not know Data or Presentation.
+```
+
+## Layer responsibilities
+
+- Domain: business models, repository contracts, use cases
+- Data: repository implementations, Retrofit services, DTOs, mappers
+- Presentation: ViewModels, UiState, events, Compose UI
+
+## BaseRepository
+
+`BaseRepository` should catch `IOException` and `HttpException`, but avoid catching generic `Exception` by default. Catching every exception can hide programming errors.
+
+## Checklist
+
+- [ ] Domain is framework-independent.
+- [ ] DTOs are separate from domain models.
+- [ ] UI does not use DTOs.
+- [ ] Results are represented explicitly.

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -1,0 +1,20 @@
+# Data Layer
+
+The data layer owns remote API access, local persistence, and repository implementations.
+
+## Shared infrastructure
+
+- `core:data`: preferences and locale handling
+- `core:database`: Room foundation
+- `core:network`: Retrofit, OkHttp, BaseRepository, auth components
+
+## Feature data module
+
+A feature data module owns that feature’s repository implementation, DTOs, mappers, and local/remote source integration.
+
+## Checklist
+
+- [ ] DTOs are separate from domain models.
+- [ ] Repository interface is in domain.
+- [ ] Implementation is in data.
+- [ ] Sensitive data is not stored as regular preferences.

--- a/docs/architecture/feature-modularization.md
+++ b/docs/architecture/feature-modularization.md
@@ -1,0 +1,28 @@
+# Feature Modularization
+
+Feature modularization is one of ComposeTemplate’s most important architectural decisions.
+
+## Structure
+
+```text
+feature/{name}/
+├── data/
+├── domain/
+├── navigation/
+└── presentation/
+```
+
+| Module | Responsibility |
+|---|---|
+| `data` | Repository implementation, DTOs, API/DB access |
+| `domain` | Use cases, domain models, repository contracts |
+| `navigation` | Routes, navigation items, bottom-bar contracts |
+| `presentation` | ViewModels, UiState/Event, Compose screens |
+
+## Checklist
+
+- [ ] Repository contract is in domain.
+- [ ] Repository implementation is in data.
+- [ ] Route is owned by navigation.
+- [ ] ScreenProvider is owned by presentation.
+- [ ] App wires feature modules explicitly.

--- a/docs/architecture/navigation-architecture.md
+++ b/docs/architecture/navigation-architecture.md
@@ -1,0 +1,25 @@
+# Navigation Architecture
+
+Navigation in ComposeTemplate is feature-owned and type-safe.
+
+## Building blocks
+
+- `INavigationItem`
+- `IBottomBarItem`
+- `INavigationManager`
+- `ScreenRegistry`
+- `IScreenProvider`
+
+## Approach
+
+Routes are modeled as type-safe Kotlin objects or data classes. Each feature registers its own screen through `IScreenProvider`. `ScreenRegistry` resolves routes from a Hilt multibound set of providers.
+
+## Bottom bar
+
+Bottom-bar items are contributed from feature navigation modules via Hilt map multibinding. This avoids a central tab list.
+
+## Checklist
+
+- [ ] Route is owned by navigation.
+- [ ] ScreenProvider is owned by presentation.
+- [ ] App module avoids feature screen details.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,43 @@
+# Architecture Overview
+
+ComposeTemplate separates app composition, shared infrastructure, product features, build logic, and performance tooling.
+
+```text
+ComposeTemplate/
+├── app/
+├── core/
+├── feature/
+├── build-logic/
+├── benchmark/
+└── baselineprofile/
+```
+
+## App module
+
+The `app` module is the composition root. It connects feature modules, configures app-level setup, owns application id/namespace, and should not contain business logic.
+
+## Core modules
+
+`core/*` modules provide reusable infrastructure: common result types, data, database, network, secrets, security, UI, navigation, analytics, config, permissions, and Google Play integrations.
+
+## Feature modules
+
+Each feature is split into four Gradle modules:
+
+```text
+feature/{name}/
+├── data
+├── domain
+├── navigation
+└── presentation
+```
+
+## Dependency direction
+
+```text
+data → domain ← presentation
+navigation → core:navigation
+presentation → navigation
+```
+
+The domain layer should not know data or presentation implementation details.

--- a/docs/architecture/ui-state-management.md
+++ b/docs/architecture/ui-state-management.md
@@ -1,0 +1,32 @@
+# UI State Management
+
+UI state management separates durable render state from one-shot events.
+
+## Pattern
+
+ViewModels follow `BaseViewModel<UiState, Event>`.
+
+- `UiState`: persistent state used to render the screen
+- `Event`: one-shot side effects such as navigation or snackbar
+
+## Example
+
+```kotlin
+data class LoginUiState(
+    val email: String = "",
+    val password: String = "",
+    val isLoading: Boolean = false,
+)
+```
+
+Use lifecycle-aware collection:
+
+```kotlin
+val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+```
+
+## Checklist
+
+- [ ] UiState is immutable.
+- [ ] One-shot effects are modeled as Event.
+- [ ] UI uses `collectAsStateWithLifecycle()`.

--- a/docs/build-system/ci-pipeline.md
+++ b/docs/build-system/ci-pipeline.md
@@ -1,0 +1,22 @@
+# CI Pipeline
+
+The CI pipeline validates both the current app and template generator behavior.
+
+## Jobs
+
+1. Lint
+2. Unit tests
+3. Debug + release build
+4. Template smoke test
+
+## Template smoke test
+
+Validates feature scaffolding, database feature scaffolding, generated feature compilation, create-new-app execution, and exclusion of local secrets from generated apps.
+
+## Checklist
+
+- [ ] Lint job exists.
+- [ ] Unit-test job exists.
+- [ ] Debug/release build job exists.
+- [ ] Scaffold smoke test exists.
+- [ ] Create-new-app smoke test exists.

--- a/docs/build-system/gradle-convention-plugins.md
+++ b/docs/build-system/gradle-convention-plugins.md
@@ -1,0 +1,23 @@
+# Gradle Convention Plugins
+
+Gradle convention plugins are the backbone of ComposeTemplate’s maintainable build system.
+
+## Why
+
+They reduce repeated Gradle configuration, keep module build files readable, centralize SDK/dependency management, and make new module creation consistent.
+
+## Important plugins
+
+- `composetemplate.android.application`
+- `composetemplate.android.library`
+- `composetemplate.android.hilt`
+- `composetemplate.android.room`
+- `composetemplate.feature.data`
+- `composetemplate.feature.domain`
+- `composetemplate.feature.navigation`
+- `composetemplate.feature.presentation`
+- `composetemplate.test`
+- `composetemplate.static.analysis`
+- `composetemplate.validate.secrets`
+- `composetemplate.create.new.app`
+- `composetemplate.scaffold.feature`

--- a/docs/build-system/static-analysis.md
+++ b/docs/build-system/static-analysis.md
@@ -1,0 +1,22 @@
+# Static Analysis
+
+Static analysis turns code quality into an automated quality gate.
+
+## Tools
+
+- Ktlint
+- Detekt
+
+## Commands
+
+```bash
+./gradlew ktlintCheck
+./gradlew detekt
+```
+
+## Checklist
+
+- [ ] CI runs Ktlint.
+- [ ] CI runs Detekt.
+- [ ] New modules are covered.
+- [ ] Suppressions are justified.

--- a/docs/build-system/version-catalog.md
+++ b/docs/build-system/version-catalog.md
@@ -1,0 +1,17 @@
+# Version Catalog
+
+The version catalog is the central place for dependency and plugin versions.
+
+## File
+
+```text
+gradle/libs.versions.toml
+```
+
+## Checklist
+
+- [ ] New dependencies are added to the version catalog.
+- [ ] Module build files avoid hardcoded versions.
+- [ ] Kotlin and KSP versions are compatible.
+- [ ] AGP/Gradle compatibility is checked.
+- [ ] Compose BOM usage is preserved.

--- a/docs/contributing/adding-a-new-feature.md
+++ b/docs/contributing/adding-a-new-feature.md
@@ -1,0 +1,17 @@
+# Adding a New Feature
+
+Use `scaffoldFeature` for a generated starting point, then adapt the generated code.
+
+```bash
+./gradlew scaffoldFeature -PfeatureName=settings
+./gradlew scaffoldFeature -PfeatureName=settings -PwithDatabase=true
+```
+
+## Manual checklist
+
+- [ ] Create data/domain/navigation/presentation modules.
+- [ ] Apply correct convention plugins.
+- [ ] Add includes to `settings.gradle.kts`.
+- [ ] Add dependencies to `app/build.gradle.kts`.
+- [ ] Create route and ScreenProvider.
+- [ ] Add Hilt bindings and tests.

--- a/docs/contributing/contribution-guide.md
+++ b/docs/contributing/contribution-guide.md
@@ -1,0 +1,30 @@
+# Contribution Guide
+
+A contribution should protect both the current app and the template generator behavior.
+
+## Local verification
+
+```bash
+./gradlew ktlintCheck detekt testDebugUnitTest assembleDebug
+```
+
+For release/security-impacting changes:
+
+```bash
+./gradlew validateSecrets :app:assembleRelease scanApkForSecrets
+```
+
+For generator-impacting changes:
+
+```bash
+./gradlew scaffoldFeature -PfeatureName=test_feature
+./gradlew create-new-app -Pargs='com.example.generated,GeneratedApp' -q --console=plain
+```
+
+## Rules
+
+- Do not add business logic to app module.
+- Keep domain modules away from Android implementation details.
+- Do not leak DTOs into UI.
+- Do not commit real secrets.
+- Do not log tokens or sensitive headers.

--- a/docs/contributing/extending-composetemplate.md
+++ b/docs/contributing/extending-composetemplate.md
@@ -1,0 +1,16 @@
+# Extending ComposeTemplate
+
+ComposeTemplate is designed to be extended.
+
+## Extension areas
+
+- Add a core module
+- Add a convention plugin
+- Extend `ScaffoldFeaturePlugin`
+- Change `CreateNewAppPlugin` rewrite rules
+- Add secret-validation rules
+- Expand CI smoke tests
+
+## Production rule
+
+Every generator-impacting extension should be tested through the template smoke path.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,63 @@
+# Getting Started
+
+This page explains how to clone ComposeTemplate and generate your own Android application.
+
+## Requirements
+
+- Android Studio Ladybug or newer
+- JDK 17+
+- Android SDK
+- Gradle wrapper
+- CMake / NDK support
+- Git
+
+Use the repository Gradle wrapper instead of a locally installed Gradle binary.
+
+## Clone
+
+```bash
+git clone https://github.com/mustafayigitt/ComposeTemplate.git
+cd ComposeTemplate
+```
+
+## Generate a new app
+
+```bash
+./gradlew create-new-app -Pargs='com.example.myapp,MyNewApp' -q --console=plain
+```
+
+The command creates a sibling project at `../MyNewApp`.
+
+## Configure secrets
+
+Create `secrets.properties` in the generated project root:
+
+```properties
+API_KEY_DEBUG="your_debug_key"
+API_KEY_RELEASE="your_release_key"
+BASE_URL_DEBUG="https://api-debug.test.com/"
+BASE_URL_RELEASE="https://api.test.com/"
+STORE_FILE="release.keystore"
+KEY_ALIAS="your_key_alias"
+KEY_PASSWORD="your_key_password"
+STORE_PASSWORD="your_store_password"
+XOR_MASK="your_custom_mask_with_24_plus_chars"
+EXPECTED_SIGNATURE_HASH="your_release_sha256_hex_with_or_without_colons"
+NATIVE_RUNTIME_CHECKS_ENABLED=true
+CERTIFICATE_PINNING_ENABLED=false
+CERTIFICATE_PINS=""
+```
+
+## Validate and build
+
+```bash
+./gradlew validateSecrets
+./gradlew ktlintCheck detekt testDebugUnitTest assembleDebug :app:assembleRelease
+```
+
+## Scaffold a feature
+
+```bash
+./gradlew scaffoldFeature -PfeatureName=settings
+./gradlew scaffoldFeature -PfeatureName=settings -PwithDatabase=true
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+# ComposeTemplate
+
+ComposeTemplate is a production-grade Jetpack Compose template generator for starting new Android projects with architecture, build tooling, CI, security hardening, and feature scaffolding already in place.
+
+## Core capabilities
+
+- Jetpack Compose UI
+- Clean Architecture
+- Feature-based multi-module architecture
+- Hilt dependency injection
+- Navigation3-based type-safe navigation
+- Retrofit + OkHttp network layer
+- Room and DataStore foundations
+- Native secret obfuscation
+- Runtime security signals
+- Gradle convention plugins
+- Feature scaffolding
+- One-command app generation
+- Ktlint + Detekt static analysis
+- CI pipeline with template smoke tests
+- Baseline Profile and Macrobenchmark modules
+
+## Quick start
+
+```bash
+git clone https://github.com/mustafayigitt/ComposeTemplate.git
+cd ComposeTemplate
+./gradlew create-new-app -Pargs='com.example.myapp,MyNewApp' -q --console=plain
+cd ../MyNewApp
+```
+
+Then run:
+
+```bash
+./gradlew validateSecrets
+./gradlew ktlintCheck detekt testDebugUnitTest assembleDebug :app:assembleRelease
+```
+
+## Recommended reading
+
+1. [Getting Started](getting-started.md)
+2. [Project Philosophy](project-philosophy.md)
+3. [Architecture Overview](architecture/overview.md)
+4. [Secret Management](security/secret-management.md)
+5. [Create New App](template-tools/create-new-app.md)
+6. [Release Readiness Checklist](quality/release-readiness-checklist.md)

--- a/docs/project-philosophy.md
+++ b/docs/project-philosophy.md
@@ -1,0 +1,31 @@
+# Project Philosophy
+
+ComposeTemplate is built around one idea:
+
+> Starting a new Android project should not require rebuilding architecture, build logic, security checks, and quality gates from scratch.
+
+## Why a template generator?
+
+A sample app says: “This is one way to do it.”
+
+A template generator says: “Generate this structure with your package name, app name, and project identity.”
+
+`create-new-app` is therefore a core capability.
+
+## Principles
+
+1. Boundaries should be visible at build level.
+2. Generator behavior must be tested.
+3. Security claims must be honest.
+4. Adding a feature should be easy.
+5. Build logic should be centralized.
+
+## Trade-offs
+
+- More modules at the start
+- A steeper learning curve
+- Gradle convention plugins require build-system knowledge
+- Native secret obfuscation adds NDK/CMake requirements
+- Generator code needs maintenance
+
+For medium and large apps, these costs are often outweighed by clearer boundaries, better testing, consistent build logic, and safer refactoring.

--- a/docs/quality/performance-baseline-profiles.md
+++ b/docs/quality/performance-baseline-profiles.md
@@ -1,0 +1,22 @@
+# Performance and Baseline Profiles
+
+ComposeTemplate includes performance infrastructure from the beginning.
+
+## Modules
+
+- `baselineprofile`
+- `benchmark`
+
+## Commands
+
+```bash
+./gradlew :baselineprofile:connectedBenchmarkAndroidTest
+./gradlew :benchmark:connectedBenchmarkAndroidTest
+```
+
+## Goals
+
+- Improve startup time
+- Improve first-screen experience
+- Reduce runtime JIT cost
+- Measure critical user journeys

--- a/docs/quality/release-readiness-checklist.md
+++ b/docs/quality/release-readiness-checklist.md
@@ -1,0 +1,31 @@
+# Release Readiness Checklist
+
+## Build
+
+- [ ] `assembleDebug` passes.
+- [ ] `:app:assembleRelease` passes.
+- [ ] Release signing is configured.
+- [ ] `isMinifyEnabled = true`.
+- [ ] `isShrinkResources = true`.
+
+## Secrets
+
+- [ ] `secrets.properties` exists and is not committed.
+- [ ] `validateSecrets` passes.
+- [ ] No placeholder secrets remain.
+- [ ] `scanApkForSecrets` runs.
+
+## Network
+
+- [ ] Cleartext traffic is disabled.
+- [ ] Sensitive headers are redacted.
+- [ ] Body logging is disabled in release.
+- [ ] Certificate-pinning decision is intentional.
+
+## Minimum command set
+
+```bash
+./gradlew validateSecrets
+./gradlew ktlintCheck detekt testDebugUnitTest assembleDebug :app:assembleRelease
+./gradlew scanApkForSecrets
+```

--- a/docs/quality/testing-strategy.md
+++ b/docs/quality/testing-strategy.md
@@ -1,0 +1,26 @@
+# Testing Strategy
+
+Testing strategy keeps architectural decisions sustainable.
+
+## Tools
+
+- JUnit
+- MockK
+- Truth
+- kotlinx-coroutines-test
+- AndroidX test dependencies
+
+## Coroutine tests
+
+Use `runTest`, not `runBlocking`.
+
+```kotlin
+@Test
+fun `loads profile successfully`() = runTest {
+    // test body
+}
+```
+
+## Template-specific tests
+
+The project should verify scaffold output, generated app creation, local secret exclusion, and native JNI behavior after rebranding.

--- a/docs/security/certificate-pinning.md
+++ b/docs/security/certificate-pinning.md
@@ -1,0 +1,18 @@
+# Certificate Pinning
+
+Certificate pinning makes MITM attacks harder but introduces operational risk.
+
+## Best practices
+
+- Use at least two pins: current and backup.
+- Prefer SPKI pins.
+- Be careful with wildcard host scope.
+- Plan certificate rotation before enabling pinning.
+- Do not treat client-only remote config as a security boundary.
+
+## Checklist
+
+- [ ] Current and backup pins exist.
+- [ ] SPKI pins are used.
+- [ ] A rotation plan exists.
+- [ ] Backend authorization remains the decision point.

--- a/docs/security/release-hardening.md
+++ b/docs/security/release-hardening.md
@@ -1,0 +1,23 @@
+# Release Hardening
+
+Release hardening prevents debug-time behavior and unsafe configuration from reaching production builds.
+
+## Checks
+
+- Release minification enabled
+- Resource shrinking enabled
+- Debuggable/profileable flags do not leak into release
+- Body logging disabled in release
+- Sensitive headers redacted
+- `validateSecrets` passes
+- `scanApkForSecrets` runs
+- Release signing configured
+
+## Example
+
+```kotlin
+release {
+    isMinifyEnabled = true
+    isShrinkResources = true
+}
+```

--- a/docs/security/runtime-security-signals.md
+++ b/docs/security/runtime-security-signals.md
@@ -1,0 +1,27 @@
+# Runtime Security Signals
+
+Runtime security should be treated as a risk-signal layer, not as a final decision layer.
+
+## Signals
+
+`core:security` can surface signals such as debugger attachment, emulator heuristics, root artifacts, hook indicators, installer source, signature mismatch, and runtime tamper signals.
+
+## Signal, not decision
+
+Avoid:
+
+```text
+if rooted -> block forever
+```
+
+Prefer:
+
+```text
+collect signals -> calculate risk -> backend decision / risk-based UX
+```
+
+## Checklist
+
+- [ ] Runtime checks are not the final decision.
+- [ ] Backend risk modeling is considered.
+- [ ] Privacy and compliance impact is reviewed.

--- a/docs/security/secret-management.md
+++ b/docs/security/secret-management.md
@@ -1,0 +1,24 @@
+# Secret Management
+
+Client-side secrets are never truly secret. ComposeTemplate focuses on increasing extraction cost and preventing accidental leakage, not replacing backend security.
+
+## Approach
+
+- `secrets.properties` for local configuration
+- `validateSecrets` for build-time validation
+- `core:secrets` for NDK/CMake-backed obfuscation
+- `scanApkForSecrets` for artifact scanning
+- `hardeningReport` for release-readiness feedback
+- `core:security` for runtime integrity signals
+
+## Build-time secrets are not real secrets
+
+Anything shipped inside an APK/AAB must be considered extractable. Native obfuscation, XOR masks, and string splitting only increase reverse-engineering cost.
+
+## Checklist
+
+- [ ] No real server secret is shipped in the APK/AAB.
+- [ ] `secrets.properties` is not committed.
+- [ ] `validateSecrets` runs before release.
+- [ ] Tokens are not logged.
+- [ ] Client hardening is not treated as backend security.

--- a/docs/template-tools/apk-aab-secret-scanning.md
+++ b/docs/template-tools/apk-aab-secret-scanning.md
@@ -1,0 +1,24 @@
+# APK/AAB Secret Scanning
+
+APK/AAB secret scanning checks whether raw secrets or masks are visible inside build artifacts.
+
+## Command
+
+```bash
+./gradlew :app:assembleRelease
+./gradlew scanApkForSecrets
+```
+
+## Scans for
+
+- API keys
+- Base URLs
+- XOR masks
+- Internal endpoints
+- Placeholder secrets
+- Native symbol names
+- Debug metadata
+
+## Limitation
+
+Artifact scanning is not a complete security guarantee. It detects known leakage patterns.

--- a/docs/template-tools/create-new-app.md
+++ b/docs/template-tools/create-new-app.md
@@ -1,0 +1,22 @@
+# Create New App
+
+`create-new-app` makes ComposeTemplate a real project generator.
+
+## Command
+
+```bash
+./gradlew create-new-app -Pargs='com.example.myapp,MyNewApp' -q --console=plain
+```
+
+## What it does
+
+- Copies the template to a sibling directory
+- Rewrites package name
+- Rewrites app name
+- Moves source directories
+- Removes generator-specific code from the generated app
+- Excludes `.git`, `.gradle`, `.idea`, `local.properties`, `secrets.properties`, and build outputs
+
+## Native JNI rebrand support
+
+ComposeTemplate uses `JNI_OnLoad` + `RegisterNatives`, with target class path provided through Gradle namespace/CMake configuration, so native bindings survive package rebranding.

--- a/docs/template-tools/scaffold-feature.md
+++ b/docs/template-tools/scaffold-feature.md
@@ -1,0 +1,28 @@
+# Scaffold Feature
+
+`scaffoldFeature` turns feature setup into a repeatable generator workflow.
+
+## Commands
+
+```bash
+./gradlew scaffoldFeature -PfeatureName=settings
+./gradlew scaffoldFeature -PfeatureName=settings -PwithDatabase=true
+```
+
+## Generated structure
+
+```text
+feature/settings/
+├── data/
+├── domain/
+├── navigation/
+└── presentation/
+```
+
+## Checklist
+
+- [ ] Four modules were generated.
+- [ ] `settings.gradle.kts` was updated.
+- [ ] App dependency wiring was added.
+- [ ] ScreenProvider resolves correctly.
+- [ ] Generated code was adapted to real needs.

--- a/docs/template-tools/validate-secrets.md
+++ b/docs/template-tools/validate-secrets.md
@@ -1,0 +1,22 @@
+# Validate Secrets
+
+`validateSecrets` catches secret/configuration mistakes before release.
+
+## Command
+
+```bash
+./gradlew validateSecrets
+```
+
+## Validates
+
+- Required keys exist
+- Placeholder values are not used
+- URL values are valid
+- XOR mask is long/strong enough
+- Signature hash format is valid
+- Pinning values are valid when enabled
+
+## Security note
+
+`validateSecrets` does not make client-side secrets truly secure. It prevents configuration mistakes and accidental leakage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,75 @@
+site_name: ComposeTemplate
+site_description: Production-grade Jetpack Compose template generator
+site_url: https://mustafayigitt.github.io/ComposeTemplate/
+repo_url: https://github.com/mustafayigitt/ComposeTemplate
+repo_name: mustafayigitt/ComposeTemplate
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Overview: index.md
+  - Start Here:
+      - Getting Started: getting-started.md
+      - Project Philosophy: project-philosophy.md
+  - Architecture:
+      - Overview: architecture/overview.md
+      - Feature Modularization: architecture/feature-modularization.md
+      - Clean Architecture: architecture/clean-architecture.md
+      - Navigation Architecture: architecture/navigation-architecture.md
+      - UI State Management: architecture/ui-state-management.md
+      - Data Layer: architecture/data-layer.md
+      - Authentication and Token Flow: architecture/authentication-token-flow.md
+  - Security:
+      - Secret Management: security/secret-management.md
+      - Runtime Security Signals: security/runtime-security-signals.md
+      - Certificate Pinning: security/certificate-pinning.md
+      - Release Hardening: security/release-hardening.md
+  - Build System:
+      - Gradle Convention Plugins: build-system/gradle-convention-plugins.md
+      - Version Catalog: build-system/version-catalog.md
+      - Static Analysis: build-system/static-analysis.md
+      - CI Pipeline: build-system/ci-pipeline.md
+  - Template Tools:
+      - Create New App: template-tools/create-new-app.md
+      - Scaffold Feature: template-tools/scaffold-feature.md
+      - Validate Secrets: template-tools/validate-secrets.md
+      - APK/AAB Secret Scanning: template-tools/apk-aab-secret-scanning.md
+  - Quality:
+      - Testing Strategy: quality/testing-strategy.md
+      - Performance and Baseline Profiles: quality/performance-baseline-profiles.md
+      - Release Readiness Checklist: quality/release-readiness-checklist.md
+  - Contributing:
+      - Adding a New Feature: contributing/adding-a-new-feature.md
+      - Extending ComposeTemplate: contributing/extending-composetemplate.md
+      - Contribution Guide: contributing/contribution-guide.md


### PR DESCRIPTION
## Summary
- Add MkDocs Material configuration for publishing the ComposeTemplate wiki via GitHub Pages
- Add structured documentation under `docs/` with architecture, security, build system, template tooling, quality, and contribution pages
- Add a GitHub Pages deployment workflow using `actions/deploy-pages`

## Notes
- After merging, enable GitHub Pages with **GitHub Actions** as the source in repository settings if it is not already enabled.
- The site will be available at `https://mustafayigitt.github.io/ComposeTemplate/` once the workflow runs successfully.

## Testing
- Not run locally in this environment.