### PR TITLE
Deepen all tech blog articles

### DIFF
--- a/docs/tech-blog/architecture/template-generator.md
+++ b/docs/tech-blog/architecture/template-generator.md
@@ -1,46 +1,79 @@
 # Building a Production-Grade Jetpack Compose Template Generator
 
-Most Android starter projects begin as sample apps. They demonstrate a stack, a folder structure, or a few architectural choices. That is useful, but it does not solve the repetitive work that every new production project needs: package renaming, module wiring, build configuration, CI, feature scaffolding, release hardening, and documentation.
+## Who this article is for
 
-ComposeTemplate approaches this differently. It is designed as a **template generator**, not just a sample application.
+This article is for Android developers and platform engineers who want to build reusable project foundations instead of repeatedly copying starter apps.
 
-## The problem with sample apps
+## What you will learn
 
-A sample app usually answers one question:
+- Why a template generator is different from a sample app
+- What must be automated for a generated Android app to be trustworthy
+- How ComposeTemplate thinks about package rewrite, cleanup, architecture, and CI
+- Common mistakes when building Android templates
 
-> How could this be implemented?
+## Sample app vs template generator
 
-A production starter needs to answer a different question:
+A sample app demonstrates an implementation. A template generator produces a new project that should be independently buildable, maintainable, and free of template-only baggage.
 
-> How can I generate a real project from this structure and continue building without carrying template-specific baggage?
+That difference matters. A sample app can leave manual rename instructions in a README. A generator must automate the rename. A sample app can keep demonstration code. A generator must produce a clean baseline developers can own.
 
-A sample app can tolerate manual setup. A generator cannot. A generator must be repeatable, predictable, and testable.
+## The real problem
 
-## What ComposeTemplate generates
+Creating a new Android app is not just creating `MainActivity`.
 
-ComposeTemplate gives a new Android project a ready foundation:
+A production-ready starter usually needs:
 
-- Jetpack Compose UI
-- Clean Architecture
-- Feature-based multi-module structure
-- Hilt dependency injection
-- Navigation3 routing
-- Retrofit/OkHttp networking
-- Room and DataStore foundations
-- Runtime and build-time security guardrails
-- Static analysis
-- CI
-- Baseline Profile and Macrobenchmark modules
-- Developer documentation
+- package and namespace setup,
+- application name replacement,
+- Gradle module wiring,
+- convention plugins,
+- CI workflows,
+- local secret exclusions,
+- signing placeholders,
+- architecture examples,
+- test setup,
+- documentation,
+- feature scaffolding.
+
+Manual clone-and-rename flows are fragile because package names and app names appear in Kotlin, XML, Gradle, resources, manifests, and sometimes native code.
+
+## ComposeTemplate approach
+
+ComposeTemplate is designed as a generator-backed template. The main generation flow is:
 
 ```bash
 ./gradlew create-new-app -Pargs='com.example.myapp,MyNewApp' -q --console=plain
 ```
 
-## Why generation matters
+The generator copies the template, rewrites project identifiers, moves source directories, excludes local-only files, and removes generator-specific build logic from the generated output.
 
-Renaming an Android project manually is fragile. Package names appear in Kotlin, XML, Gradle files, manifests, resources, and sometimes native bindings. ComposeTemplate automates this process and removes template-specific generator code from the generated app.
+## Why cleanup matters
 
-## Takeaway
+Generated apps should not keep template-only internals unless they are useful to the app. If a generated project still contains the generator that created it, developers inherit maintenance burden they did not ask for.
 
-A production-grade template is not just a folder structure. It is a system made of architecture, build logic, generators, tests, CI, security guardrails, and documentation.
+## Template quality checklist
+
+- [ ] Generated app builds without manual package fixes.
+- [ ] Local files such as `local.properties` and `secrets.properties` are not copied.
+- [ ] Template-only tasks are removed from generated output.
+- [ ] Native bindings survive package rename.
+- [ ] CI validates generated output, not just the template source.
+- [ ] Documentation explains what was generated and why.
+
+## Common mistakes
+
+### Treating README steps as automation
+
+If a step is required every time, automate it.
+
+### Forgetting native and resource references
+
+Package names can appear outside Kotlin files.
+
+### Not testing the generated app
+
+The generated app is the product. CI should prove it works.
+
+## Summary
+
+A production-grade template is a system: architecture, build logic, generator tasks, quality gates, security guardrails, performance tooling, and documentation. ComposeTemplate treats generation as a first-class engineering problem, not a copy-paste convenience.

--- a/docs/tech-blog/architecture/ui-state-one-shot-events.md
+++ b/docs/tech-blog/architecture/ui-state-one-shot-events.md
@@ -1,25 +1,101 @@
 # UI State and One-Shot Events in Jetpack Compose
 
-Compose UI is easiest to reason about when persistent render state and one-shot effects are modeled separately.
+## Who this article is for
 
-## Problem
+This article is for Compose developers building screens with ViewModels, flows, navigation events, loading states, and user actions.
 
-Navigation events, snackbars, loading flags, and form state often get mixed into one state object. This leads to repeated events, stale messages, and hard-to-test ViewModels.
+## What you will learn
 
-## ComposeTemplate approach
+- Why render state and one-shot effects should be separate
+- How `StateFlow` and event flows play different roles
+- How this maps to Compose screens
+- Common mistakes that cause repeated navigation or stale snackbar messages
 
-ViewModels follow `BaseViewModel<UiState, Event>`.
+## The problem
 
-- `UiState` represents durable render state.
-- `Event` represents one-shot effects like navigation or snackbar messages.
+UI has two kinds of information.
+
+The first kind is durable state:
+
+- current email text,
+- loading flag,
+- list of items,
+- selected tab,
+- validation errors.
+
+The second kind is a one-time effect:
+
+- navigate to another screen,
+- show a snackbar,
+- open a dialog once,
+- trigger a toast,
+- request focus.
+
+If both are stored in one persistent state object, effects can repeat after recomposition, configuration change, or process recreation.
+
+## Mental model
+
+State describes what the UI should look like.
+
+Events describe what should happen once.
 
 ```kotlin
 data class LoginUiState(
     val email: String = "",
+    val password: String = "",
     val isLoading: Boolean = false,
+    val errorMessage: String? = null,
 )
+
+sealed interface LoginEvent {
+    data object NavigateHome : LoginEvent
+    data class ShowMessage(val message: String) : LoginEvent
+}
 ```
 
-## Takeaway
+## ComposeTemplate approach
 
-Good Compose state management is less about APIs and more about separating what the UI is from what the UI does once.
+ComposeTemplate uses a `BaseViewModel<UiState, Event>` pattern. The state is exposed as observable state for rendering. Events are emitted separately for one-time effects.
+
+This gives every feature the same structure:
+
+- ViewModel owns state transitions.
+- Compose renders state.
+- Compose collects events in effect handlers.
+- Navigation is not stored as durable state.
+
+## Lifecycle-aware collection
+
+State should be collected with lifecycle awareness:
+
+```kotlin
+val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+```
+
+Events should be collected in a `LaunchedEffect` or a lifecycle-aware helper depending on the project conventions.
+
+## Common mistakes
+
+### Storing navigation in state
+
+A flag like `shouldNavigate = true` can trigger navigation repeatedly unless it is reset carefully.
+
+### Using nullable message as an event
+
+`snackbarMessage: String?` often becomes stale state. Prefer one-shot events for transient messages.
+
+### Letting composables contain business decisions
+
+Composable functions should render and forward user actions. ViewModels should decide state transitions.
+
+## Production checklist
+
+- [ ] UI state is immutable.
+- [ ] One-shot effects are modeled separately.
+- [ ] State collection is lifecycle-aware.
+- [ ] Navigation is emitted as an event.
+- [ ] ViewModel tests verify state transitions and emitted effects.
+
+## Summary
+
+Compose state management becomes easier when durable state and transient effects are separated. ComposeTemplate standardizes this pattern so feature screens behave consistently and remain testable.

--- a/docs/tech-blog/build-system/ksp-hilt-build-logic.md
+++ b/docs/tech-blog/build-system/ksp-hilt-build-logic.md
@@ -1,23 +1,75 @@
 # KSP, Hilt and Build Logic Integration
 
-Dependency injection in a multi-module Android project should be consistent, repeatable, and easy to apply to new modules.
+## Who this article is for
 
-## Problem
+This article is for Android developers using Hilt, annotation processing, and multiple Gradle modules.
 
-Without shared build logic, every module repeats Hilt and KSP setup. This creates config drift and makes new modules harder to add.
+## What you will learn
+
+- What KSP does
+- Why DI setup should be centralized
+- How Hilt multibinding supports modular architecture
+- Why build logic matters for generated code tools
+
+## What KSP is
+
+KSP stands for Kotlin Symbol Processing. It lets libraries inspect Kotlin symbols and generate code during compilation.
+
+Many Android libraries use code generation. Hilt uses generated components and factories. Room uses generated database and DAO implementations.
+
+Because generated code participates in compilation, KSP setup must be correct in every module that needs it.
+
+## The problem in multi-module projects
+
+Without convention plugins, each module repeats:
+
+- Hilt plugin application,
+- KSP plugin application,
+- compiler dependency setup,
+- generated source configuration,
+- test dependency setup.
+
+One missing line can break the module or produce confusing errors.
 
 ## ComposeTemplate approach
 
-ComposeTemplate centralizes DI setup in convention plugins. Feature modules apply the right plugin for their layer, and Hilt/KSP wiring is handled consistently.
+ComposeTemplate centralizes Hilt and KSP setup through convention plugins. Feature modules apply layer-specific plugins, and the build logic decides which dependencies and processors are needed.
+
+This keeps module build files short and consistent.
 
 ## Hilt multibinding
 
-ComposeTemplate uses Hilt multibinding for scalable feature registration:
+Multibinding allows multiple modules to contribute implementations into a set or map.
 
-- Screen providers can be contributed with `@IntoSet`.
-- Bottom-bar items can be contributed with `@IntoMap`.
-- App-level code does not need to know every concrete feature implementation.
+That is useful for modular features:
 
-## Takeaway
+```kotlin
+@Binds
+@IntoSet
+abstract fun bindProvider(provider: FeatureScreenProvider): ScreenProvider
+```
 
-DI setup is build architecture. Centralizing it keeps feature modules predictable and easier to scale.
+The app can receive `Set<ScreenProvider>` without manually knowing each feature provider.
+
+## Why this matters for templates
+
+Generated features should be wired the same way as hand-written features. Centralized build logic ensures scaffolded modules get the same Hilt/KSP setup as existing modules.
+
+## Common mistakes
+
+- Applying Hilt plugin but forgetting compiler dependency.
+- Updating Kotlin without matching KSP.
+- Creating feature modules that bypass convention plugins.
+- Using DI as a service locator instead of dependency wiring.
+
+## Production checklist
+
+- [ ] Hilt setup is centralized.
+- [ ] KSP version matches Kotlin.
+- [ ] Generated feature modules apply the same conventions.
+- [ ] Multibinding is used for feature registration where appropriate.
+- [ ] CI compiles scaffolded features.
+
+## Summary
+
+KSP and Hilt are not just library choices. In a modular project, they are part of the build architecture. ComposeTemplate centralizes their setup to keep feature modules reliable and generator-friendly.

--- a/docs/tech-blog/build-system/version-catalog-dependency-governance.md
+++ b/docs/tech-blog/build-system/version-catalog-dependency-governance.md
@@ -1,21 +1,89 @@
 # Version Catalog and Dependency Governance in Android
 
-Dependency management becomes a governance problem in multi-module Android projects. ComposeTemplate centralizes versions through Gradle Version Catalog.
+## Who this article is for
 
-## Problem
+This article is for Android developers maintaining projects with many modules and many dependencies.
 
-Hardcoded versions spread across modules create drift. Kotlin, KSP, AGP, Compose, Hilt, and Room compatibility must be managed together.
+## What you will learn
 
-## ComposeTemplate approach
+- Why dependency versions become a governance problem
+- How Gradle Version Catalog works
+- Why Compose BOM matters
+- How Kotlin, KSP and AGP compatibility should be managed
+- Common dependency-management mistakes
 
-All versions live in:
+## The problem
+
+In small projects, dependency versions are easy to see. In multi-module projects, versions can spread across many `build.gradle.kts` files.
+
+That creates risk:
+
+- different modules use different versions,
+- KSP and Kotlin become incompatible,
+- Compose libraries drift,
+- dependency updates are hard to review,
+- security and maintenance updates are missed.
+
+## Version Catalog mental model
+
+A Gradle Version Catalog centralizes dependency coordinates and versions in:
 
 ```text
 gradle/libs.versions.toml
 ```
 
-The catalog groups SDK, AndroidX, Compose, Navigation, Network, Hilt, Kotlin, testing, static analysis, benchmarking, and build tooling versions.
+It usually contains:
 
-## Takeaway
+- `[versions]` for version numbers,
+- `[libraries]` for library aliases,
+- `[plugins]` for plugin aliases.
 
-A version catalog is not just cleanup. It is the dependency governance layer of a modern Android project.
+Modules then reference aliases instead of hardcoding coordinates.
+
+## ComposeTemplate approach
+
+ComposeTemplate keeps AndroidX, Compose, Navigation3, Hilt, Room, Retrofit, OkHttp, testing, benchmark, static analysis, and build tool versions in the version catalog.
+
+This is especially important because several tools must align:
+
+- Kotlin and KSP,
+- Android Gradle Plugin and Gradle,
+- Compose compiler and Kotlin,
+- Room compiler and KSP,
+- Hilt compiler and KSP.
+
+## Compose BOM
+
+Compose uses a Bill of Materials. A BOM aligns Compose artifact versions so each Compose dependency does not need its own explicit version.
+
+This reduces mismatch risk across UI dependencies.
+
+## Renovate and update strategy
+
+Automated tools can open update PRs, but version updates are still engineering changes. For Android projects, updates should consider build compatibility, runtime behavior, and generated template output.
+
+## Common mistakes
+
+### Updating Kotlin without KSP
+
+KSP versions are tied to Kotlin. Updating one without the other can break compilation.
+
+### Mixing Compose BOM with explicit Compose versions
+
+That defeats part of the BOM’s purpose.
+
+### Treating dependency updates as mechanical
+
+Some updates change generated code, compiler behavior, lint rules, or runtime performance.
+
+## Production checklist
+
+- [ ] Versions are centralized in `libs.versions.toml`.
+- [ ] Compose uses a BOM consistently.
+- [ ] Kotlin and KSP are updated together.
+- [ ] Dependency update PRs run full CI.
+- [ ] Template smoke tests run after build-tool updates.
+
+## Summary
+
+A version catalog is not just a nicer syntax. It is dependency governance for a multi-module Android project. ComposeTemplate uses it to make upgrades visible, reviewable, and consistent.

--- a/docs/tech-blog/index.md
+++ b/docs/tech-blog/index.md
@@ -1,14 +1,17 @@
 # Tech Blog Series
 
-Developer-oriented technical articles explaining the architecture, tooling, security, performance, and developer-experience decisions behind ComposeTemplate.
+The ComposeTemplate Tech Blog Series teaches the technologies and engineering decisions behind the template. These articles are written as developer learning resources, not feature lists.
 
-## Architecture and Build System
+## Architecture
 
 - [Building a Production-Grade Jetpack Compose Template Generator](architecture/template-generator.md)
 - [Feature Modularization with Clean Architecture in Android](architecture/feature-modularization-clean-architecture.md)
-- [Gradle Convention Plugins for Scalable Android Projects](build-system/gradle-convention-plugins-scalable-android.md)
 - [Navigation3 with Feature-Owned Screen Registration](architecture/navigation3-feature-owned-screen-registration.md)
 - [UI State and One-Shot Events in Jetpack Compose](architecture/ui-state-one-shot-events.md)
+
+## Build System
+
+- [Gradle Convention Plugins for Scalable Android Projects](build-system/gradle-convention-plugins-scalable-android.md)
 - [Version Catalog and Dependency Governance in Android](build-system/version-catalog-dependency-governance.md)
 - [KSP, Hilt and Build Logic Integration](build-system/ksp-hilt-build-logic.md)
 

--- a/docs/tech-blog/performance/measuring-generated-templates.md
+++ b/docs/tech-blog/performance/measuring-generated-templates.md
@@ -1,20 +1,73 @@
 # Measuring Generated Templates, Not Just Apps
 
-Template performance matters because generated apps inherit the template’s defaults.
+## Who this article is for
 
-## Problem
+This article is for template maintainers and platform teams who want generated apps to inherit good performance defaults.
 
-A template can look clean but generate apps with slow startup, unnecessary dependencies, or poorly configured performance tooling.
+## What you will learn
+
+- Why template performance matters
+- Why measuring only the source app is incomplete
+- How generated app validation can evolve
+- How Baseline Profiles and Macrobenchmark fit template quality
+
+## The problem
+
+A template can build successfully and still generate apps with poor startup behavior, unnecessary dependencies, or broken performance tooling.
+
+If users generate apps from the template, the generated output is the real product.
+
+## Smoke testing vs performance testing
+
+A smoke test asks:
+
+```text
+Does the generated app build?
+```
+
+A performance test asks:
+
+```text
+Does the generated app start and behave well?
+```
+
+Both matter.
 
 ## ComposeTemplate approach
 
-ComposeTemplate includes performance modules from the beginning:
+ComposeTemplate includes:
 
 - `baselineprofile`
 - `benchmark`
+- generator smoke tests
+- scaffold smoke tests
 
-This makes generated apps performance-aware on day one.
+This creates a foundation for future generated-app performance validation.
 
-## Takeaway
+## What mature template performance could include
 
-For template repositories, performance should be measured where users experience it: in the generated app.
+- Generate app in CI.
+- Build release variant.
+- Run startup Macrobenchmark.
+- Generate Baseline Profile for generated package.
+- Store performance reports as artifacts.
+- Track regressions over time.
+
+## Common mistakes
+
+- Measuring only the template app.
+- Ignoring generated package names in benchmark setup.
+- Treating smoke tests as performance tests.
+- Adding heavy startup dependencies to the template.
+
+## Production checklist
+
+- [ ] Template app has benchmark coverage.
+- [ ] Generated app builds in CI.
+- [ ] Generated app can run performance tests.
+- [ ] Baseline profile paths survive package rename.
+- [ ] Startup regressions are tracked over time.
+
+## Summary
+
+Template performance should be measured where users experience it: generated apps. ComposeTemplate includes the foundations needed to make this possible.

--- a/docs/tech-blog/quality-dx/docs-as-code-mkdocs-github-pages.md
+++ b/docs/tech-blog/quality-dx/docs-as-code-mkdocs-github-pages.md
@@ -1,21 +1,61 @@
 # Docs-as-Code with MkDocs and GitHub Pages
 
-Good developer documentation should live close to the code and evolve with it.
+## Who this article is for
 
-## Problem
+This article is for open-source maintainers and engineering teams that want project documentation to evolve with code.
 
-Project documentation often starts in a README, grows too large, and then becomes hard to maintain. External wiki systems can drift away from the repository.
+## What you will learn
+
+- Why README-only documentation does not scale
+- What docs-as-code means
+- Why MkDocs Material works well for developer docs
+- How GitHub Pages deployment fits the workflow
+
+## The problem
+
+A README is a good entry point, but it becomes overloaded as a project grows. Architecture, security, build system, performance, and contribution docs need structure.
+
+External wiki systems can drift because changes are not reviewed with code.
+
+## Docs-as-code mental model
+
+Documentation lives in the repository as Markdown. Changes go through pull requests, review, CI, and version history.
+
+This makes documentation part of the engineering workflow.
 
 ## ComposeTemplate approach
 
-ComposeTemplate uses docs-as-code:
+ComposeTemplate uses:
 
-- Markdown files under `docs/`
-- `mkdocs.yml` for navigation
-- MkDocs Material for presentation
-- GitHub Actions for deployment
-- GitHub Pages for hosting
+- `docs/` for Markdown pages,
+- `mkdocs.yml` for navigation,
+- MkDocs Material for site rendering,
+- GitHub Actions for deployment,
+- GitHub Pages for hosting.
 
-## Takeaway
+## Why MkDocs Material
 
-Documentation is part of the product. Treating docs as code keeps it reviewable, versioned, and close to the engineering decisions it explains.
+MkDocs Material provides navigation, search, code highlighting, admonitions, and a polished reading experience while keeping content in Markdown.
+
+## CI and deployment
+
+The Pages workflow builds the site and deploys it. This means broken navigation or invalid docs configuration can be caught before publishing.
+
+## Common mistakes
+
+- Keeping important docs only in README.
+- Publishing docs that are not reviewed.
+- Letting navigation drift from file structure.
+- Not testing documentation builds.
+
+## Production checklist
+
+- [ ] Docs live in the repository.
+- [ ] Navigation is defined in `mkdocs.yml`.
+- [ ] Docs build in CI.
+- [ ] README links to the documentation site.
+- [ ] Architecture and security docs are reviewed like code.
+
+## Summary
+
+Documentation is part of developer experience. ComposeTemplate uses docs-as-code so documentation remains versioned, reviewable, and close to implementation decisions.

--- a/docs/tech-blog/quality-dx/retrofit-okhttp-network-layer.md
+++ b/docs/tech-blog/quality-dx/retrofit-okhttp-network-layer.md
@@ -1,25 +1,86 @@
 # Retrofit, OkHttp and Network Layer Design
 
-A reusable Android template needs a network layer that is practical, secure by default, and easy for feature modules to consume.
+## Who this article is for
 
-## Problem
+This article is for Android developers designing a reusable network layer for feature-based apps.
 
-Network code often becomes scattered across features. Token injection, logging, error handling, and refresh behavior may be duplicated or implemented inconsistently.
+## What you will learn
+
+- What Retrofit and OkHttp are responsible for
+- Why interceptors and authenticators should be separated
+- How network error handling should be modeled
+- Why logging must be safe by default
+
+## Network layer responsibilities
+
+A production network layer usually handles:
+
+- request creation,
+- serialization,
+- authentication headers,
+- token refresh,
+- error mapping,
+- connectivity awareness,
+- logging and redaction,
+- base URL configuration.
+
+Mixing these concerns inside feature repositories leads to duplication and inconsistent behavior.
+
+## Retrofit vs OkHttp
+
+Retrofit defines API interfaces and maps HTTP calls into Kotlin-friendly service methods.
+
+OkHttp executes HTTP requests and provides lower-level hooks such as interceptors, authenticators, connection settings, and certificate pinning.
+
+They solve different layers of the network stack.
+
+## Interceptor vs Authenticator
+
+An interceptor decorates or observes requests. For example, `AuthInterceptor` can attach an access token.
+
+An authenticator reacts to authentication failures. For example, `TokenAuthenticator` can respond to HTTP 401 by refreshing tokens and retrying.
+
+Keeping these separate prevents request decoration from becoming recovery logic.
 
 ## ComposeTemplate approach
 
-ComposeTemplate centralizes network infrastructure in `core:network`.
+ComposeTemplate centralizes network infrastructure in `core:network`, including:
 
-Key pieces:
+- Retrofit,
+- OkHttp,
+- AuthInterceptor,
+- TokenAuthenticator,
+- BaseRepository,
+- NetworkMonitor,
+- sensitive header redaction.
 
-- Retrofit
-- OkHttp
-- AuthInterceptor
-- TokenAuthenticator
-- BaseRepository
-- NetworkMonitor
-- sensitive header redaction
+Feature data modules consume this shared infrastructure instead of rebuilding it.
 
-## Takeaway
+## Error handling
 
-A good network layer is not just Retrofit setup. It is a boundary for auth, errors, logging, connectivity, and security expectations.
+Network errors should be mapped into domain-friendly results. A base repository can catch expected errors such as IO and HTTP failures, but it should avoid swallowing programming errors with overly broad catches.
+
+## Safe logging
+
+HTTP logging is useful in debug builds but dangerous in release builds. Sensitive headers such as `Authorization`, cookies, API keys, and auth tokens should be redacted.
+
+## Common mistakes
+
+- Logging request/response bodies in release.
+- Refreshing tokens inside every repository.
+- Treating all exceptions the same.
+- Exposing DTOs directly to UI.
+- Forgetting offline/connectivity behavior.
+
+## Production checklist
+
+- [ ] Auth header injection is centralized.
+- [ ] Token refresh is handled separately from request decoration.
+- [ ] Sensitive headers are redacted.
+- [ ] Release logging is disabled or safe.
+- [ ] Network errors are mapped intentionally.
+- [ ] Feature modules do not duplicate client setup.
+
+## Summary
+
+A good network layer is not just Retrofit setup. It is a boundary for authentication, error handling, logging, connectivity, and security expectations.

--- a/docs/tech-blog/quality-dx/static-analysis-ktlint-detekt.md
+++ b/docs/tech-blog/quality-dx/static-analysis-ktlint-detekt.md
@@ -1,25 +1,59 @@
 # Static Analysis with Ktlint and Detekt
 
-Static analysis turns code quality into an automated system instead of a review preference.
+## Who this article is for
 
-## Problem
+This article is for Android teams that want consistent style and quality checks without relying only on code review comments.
 
-Without automated checks, pull requests spend time on formatting debates, style drift, and preventable code smells.
+## What you will learn
+
+- What Ktlint and Detekt solve
+- Why static analysis should be centralized
+- How CI turns quality rules into gates
+- Common mistakes in rule management
+
+## The problem
+
+Without automation, teams spend review time on formatting, naming, complexity, and preventable code smells. Reviews become inconsistent because each reviewer has different preferences.
+
+## Ktlint vs Detekt
+
+Ktlint focuses on Kotlin formatting and style consistency.
+
+Detekt focuses on static analysis: complexity, potential bugs, maintainability issues, and project-specific rules.
+
+They are complementary.
 
 ## ComposeTemplate approach
 
 ComposeTemplate uses:
-
-- Ktlint for formatting
-- Detekt for code quality
-- a static-analysis convention plugin
-- CI enforcement
 
 ```bash
 ./gradlew ktlintCheck
 ./gradlew detekt
 ```
 
-## Takeaway
+Static analysis is wired through convention plugins so new modules inherit the same quality gates.
 
-Static analysis is not about style perfection. It is about making quality consistent and reviewable at scale.
+## Why convention plugins matter
+
+If static analysis is configured manually per module, new modules can forget to apply it. Centralized build logic makes quality checks part of the project platform.
+
+## Common mistakes
+
+- Adding too many strict rules at once.
+- Suppressing warnings without explanation.
+- Letting generated code trigger irrelevant checks.
+- Running checks locally but not in CI.
+
+## Production checklist
+
+- [ ] Ktlint runs in CI.
+- [ ] Detekt runs in CI.
+- [ ] Rules are documented.
+- [ ] Suppressions are justified.
+- [ ] New modules inherit checks automatically.
+- [ ] Generated code handling is defined.
+
+## Summary
+
+Static analysis is not about perfection. It is about making quality consistent, automated, and reviewable across a growing Android codebase.

--- a/docs/tech-blog/quality-dx/testing-stack-junit-mockk-truth-coroutines.md
+++ b/docs/tech-blog/quality-dx/testing-stack-junit-mockk-truth-coroutines.md
@@ -1,21 +1,76 @@
 # Testing Stack: JUnit, MockK, Truth and Coroutine Tests
 
-A production template needs a predictable testing stack that feature modules can reuse.
+## Who this article is for
 
-## Problem
+This article is for Android developers writing unit tests for ViewModels, use cases, repositories, and coroutine-based code.
 
-Without a standard test setup, each module invents its own testing style. Coroutine tests become flaky, assertions become inconsistent, and ViewModel behavior becomes hard to verify.
+## What you will learn
+
+- What each testing library is responsible for
+- Why coroutine tests need special handling
+- When to use mocks vs fakes
+- How a convention plugin improves test consistency
+
+## Testing stack roles
+
+ComposeTemplate standardizes common test tools:
+
+- JUnit for test structure,
+- MockK for mocks and verification,
+- Truth for readable assertions,
+- kotlinx-coroutines-test for coroutine execution control,
+- AndroidX test libraries for Android-related tests.
+
+## Coroutine testing
+
+Coroutine tests should use `runTest`:
+
+```kotlin
+@Test
+fun loadsData() = runTest {
+    // test body
+}
+```
+
+`runTest` provides a test scheduler and avoids many timing problems associated with real dispatchers.
+
+ViewModel tests may need a main dispatcher rule when `viewModelScope` is involved.
+
+## MockK vs fakes
+
+Mocks are useful for verifying interactions. Fakes are useful when a dependency has meaningful behavior.
+
+Use mocks for small isolated collaborations. Use fakes when the test should exercise realistic state changes.
+
+## Truth assertions
+
+Truth makes assertions readable:
+
+```kotlin
+assertThat(result).isEqualTo(expected)
+```
+
+Readable assertions make failures easier to understand.
 
 ## ComposeTemplate approach
 
-ComposeTemplate standardizes testing through a test convention plugin and common dependencies:
+The test convention plugin applies common test dependencies so feature modules do not reinvent test setup.
 
-- JUnit
-- MockK
-- Truth
-- kotlinx-coroutines-test
-- AndroidX test libraries
+## Common mistakes
 
-## Takeaway
+- Using real dispatchers in unit tests.
+- Over-mocking domain logic.
+- Testing implementation details instead of behavior.
+- Forgetting to test one-shot events separately from state.
 
-A shared testing stack is part of developer experience. It makes new feature tests easier to write and easier to review.
+## Production checklist
+
+- [ ] Coroutine tests use `runTest`.
+- [ ] Main dispatcher is controlled in ViewModel tests.
+- [ ] Assertions are readable.
+- [ ] Mocks and fakes are chosen intentionally.
+- [ ] Test dependencies are centralized.
+
+## Summary
+
+A shared testing stack improves developer experience and review quality. ComposeTemplate standardizes test dependencies so feature tests are easier to write consistently.

--- a/docs/tech-blog/security/certificate-pinning-security-operational-risk.md
+++ b/docs/tech-blog/security/certificate-pinning-security-operational-risk.md
@@ -1,18 +1,59 @@
 # Certificate Pinning: Security vs Operational Risk
 
-Certificate pinning can make man-in-the-middle attacks harder, but it also adds operational risk.
+## Who this article is for
 
-## Problem
+This article is for Android developers responsible for network security, OkHttp configuration, or mobile release operations.
 
-HTTPS relies on the platform trust store. On compromised or managed devices, trust can be manipulated. Pinning narrows trust by requiring the server certificate chain to match expected public keys.
+## What you will learn
 
-## Best practices
+- What certificate pinning protects against
+- Why SPKI pins are preferred
+- Why pinning can break production apps
+- How to plan rotation and recovery
 
-- Pin SPKI hashes, not entire leaf certificates.
-- Keep at least two pins: current and backup.
-- Avoid overly broad wildcard host scopes.
-- Plan certificate rotation before enabling pinning.
+## The problem
 
-## Takeaway
+HTTPS trusts certificate authorities in the platform trust store. In some environments, that trust can be modified or abused. Certificate pinning narrows trust by requiring the server certificate chain to match known public key hashes.
 
-Certificate pinning is useful when operated carefully. Without rotation planning, it can become an availability risk.
+## What pinning protects against
+
+Pinning can make some man-in-the-middle attacks harder, especially when a malicious or user-installed CA is involved.
+
+It does not protect against compromised app code, runtime hooks, stolen tokens, backend authorization flaws, or malicious servers that legitimately own the pinned key.
+
+## SPKI pinning
+
+Pin the Subject Public Key Info hash rather than an entire certificate. Certificates rotate more often than public keys. SPKI pinning gives better operational flexibility.
+
+## Backup pins
+
+Always keep at least one backup pin. Without a backup, certificate rotation can brick network access for existing app versions.
+
+## ComposeTemplate approach
+
+ComposeTemplate treats certificate pinning as a configurable hardening layer. That is important because pinning should not be enabled casually. It needs release planning.
+
+## Operational risks
+
+Pinning failure is an availability issue. If pins are wrong, the app cannot connect. Mobile clients are slow to update, so bad pins can remain in the wild.
+
+## Common mistakes
+
+- Pinning without backup pins.
+- Pinning leaf certificates instead of SPKI.
+- Forgetting staging vs production hosts.
+- Using broad wildcard assumptions.
+- No emergency rotation plan.
+
+## Production checklist
+
+- [ ] SPKI pins are used.
+- [ ] Current and backup pins exist.
+- [ ] Rotation process is documented.
+- [ ] Staging and production hosts are separated.
+- [ ] Monitoring exists for pinning failures.
+- [ ] Emergency release plan exists.
+
+## Summary
+
+Certificate pinning is a useful hardening tool, but it is also operationally dangerous. ComposeTemplate frames it as an optional security layer that requires rotation discipline.

--- a/docs/tech-blog/security/runtime-integrity-signals.md
+++ b/docs/tech-blog/security/runtime-integrity-signals.md
@@ -1,15 +1,73 @@
 # Runtime Integrity Signals on Android
 
-Runtime integrity checks are useful, but they should not be treated as final security decisions.
+## Who this article is for
 
-## Problem
+This article is for Android developers adding root, debugger, emulator, hook, installer, or signature checks to an app.
 
-Root detection, debugger detection, emulator checks, and hook detection can all be bypassed by a motivated attacker. If the client makes the final decision, the attacker can patch the client.
+## What you will learn
+
+- Why client-side integrity checks are bypassable
+- How to think about checks as risk signals
+- What kinds of signals are useful
+- Operational and privacy concerns
+
+## The problem
+
+Apps often want to know whether they are running in a risky environment. Examples include rooted devices, emulators, attached debuggers, hook frameworks, repackaged APKs, or unknown installers.
+
+The mistake is treating the client check as a final security decision.
+
+A motivated attacker can patch client code, hook functions, fake results, or modify control flow.
+
+## Better mental model
+
+Runtime integrity should be modeled as signals:
+
+```text
+collect signals -> evaluate risk -> decide response
+```
+
+The response might be local UX changes, reduced trust, server-side risk scoring, or additional verification.
 
 ## ComposeTemplate approach
 
-`core:security` provides runtime signals such as debugger attachment, emulator heuristics, root indicators, hook indicators, installer source, signature mismatch, and tamper signals.
+ComposeTemplate’s `core:security` exposes runtime security signals such as:
 
-## Takeaway
+- debugger attachment,
+- emulator heuristics,
+- root indicators,
+- hook indicators,
+- installer source,
+- signature mismatch,
+- tamper indicators.
 
-Runtime integrity should raise risk awareness, not pretend to be unbreakable client-side security.
+The important point is not that any single signal is perfect. The value is in combining weak signals into a risk picture.
+
+## Red-oracle risk
+
+Do not give attackers precise failure messages like `FRIDA_DETECTED`. That tells them exactly what to patch.
+
+Prefer generic responses and server-side correlation where appropriate.
+
+## Privacy considerations
+
+Integrity signals can become fingerprinting data. Collect the minimum needed, document why it is collected, and define retention policy.
+
+## Common mistakes
+
+- Blocking only on one weak signal.
+- Exposing detailed detection reasons.
+- Treating root detection as complete protection.
+- Collecting excessive device data.
+
+## Production checklist
+
+- [ ] Signals are documented as bypassable.
+- [ ] No single signal is treated as absolute truth.
+- [ ] User-facing errors do not reveal detection internals.
+- [ ] Backend risk scoring is considered for sensitive flows.
+- [ ] Privacy and retention are documented.
+
+## Summary
+
+Runtime integrity checks are useful when treated honestly. ComposeTemplate models them as risk signals, not unbreakable client-side security.

--- a/docs/tech-blog/security/secret-validation-apk-aab-secret-scanning.md
+++ b/docs/tech-blog/security/secret-validation-apk-aab-secret-scanning.md
@@ -1,20 +1,77 @@
 # Secret Validation and APK/AAB Secret Scanning
 
-Security issues often come from release mistakes, not only from cryptography or backend design.
+## Who this article is for
 
-## Problem
+This article is for Android developers, release engineers, and DevSecOps teams who want guardrails against accidental secret leakage.
 
-A release build can accidentally ship with placeholder keys, malformed URLs, weak masks, debug metadata, or raw secrets visible inside the final artifact.
+## What you will learn
+
+- Why release mistakes are common
+- What secret validation should catch
+- What artifact scanning can and cannot prove
+- How ComposeTemplate uses validation and scanning as release guardrails
+
+## The problem
+
+Many mobile security issues come from configuration mistakes:
+
+- placeholder API keys,
+- debug endpoints,
+- malformed URLs,
+- weak masks,
+- wrong signature hashes,
+- raw values visible in APK/AAB output.
+
+These mistakes are preventable with build-time checks.
+
+## Validation vs scanning
+
+Validation happens before or during build. It checks whether configuration values are present, well-formed, and not obvious placeholders.
+
+Artifact scanning happens after build. It inspects generated outputs for known raw values or suspicious strings.
+
+Both are useful. Neither proves the app is secure.
 
 ## ComposeTemplate approach
 
-ComposeTemplate uses two guardrails:
+ComposeTemplate provides tasks such as:
 
 - `validateSecrets`
 - `scanApkForSecrets`
+- `hardeningReport`
 
-`validateSecrets` checks configuration before the app is built. `scanApkForSecrets` checks generated APK/AAB artifacts for known raw values.
+The goal is to fail early when release configuration looks unsafe.
 
-## Takeaway
+## What validation catches
 
-Validation and artifact scanning are release guardrails. They do not make client-side secrets safe, but they prevent avoidable mistakes.
+- Missing required properties
+- Placeholder values
+- Malformed base URLs
+- Weak XOR masks
+- Invalid signature hash format
+- Inconsistent certificate pinning configuration
+
+## What scanning catches
+
+- Raw API keys
+- Base URLs
+- Internal endpoints
+- Placeholder strings
+- Debug metadata
+- Known secret values in final artifacts
+
+## Limitations
+
+A scan only finds what it knows to look for. It cannot prove that no sensitive value exists. It also does not protect runtime memory or backend authorization.
+
+## Production checklist
+
+- [ ] Release builds run secret validation.
+- [ ] APK/AAB artifacts are scanned.
+- [ ] Placeholder values fail the build.
+- [ ] Reports are reviewable in CI.
+- [ ] Real backend secrets are never stored in the client.
+
+## Summary
+
+Secret validation and artifact scanning are practical release guardrails. ComposeTemplate uses them to catch avoidable mistakes before they reach production.

--- a/docs/tech-blog/template-engineering/android-template-generator-gradle.md
+++ b/docs/tech-blog/template-engineering/android-template-generator-gradle.md
@@ -1,21 +1,72 @@
 # Building an Android Template Generator with Gradle
 
-A template generator must do more than copy files. It must produce a clean, independent project that no longer depends on the original template repository.
+## Who this article is for
 
-## Problem
+This article is for Android developers who want to build project generators, internal app templates, or reusable mobile platform foundations.
 
-Manual clone-and-rename flows are fragile. Package names appear in Kotlin, XML, Gradle, properties, resources, manifests, and native code.
+## What you will learn
+
+- Why clone-and-rename is fragile
+- What a generator must rewrite
+- Why generated apps should remove generator code
+- How CI should validate generated output
+
+## The problem with manual rename
+
+Android project identity is scattered across many places:
+
+- package declarations,
+- namespace and applicationId,
+- manifest values,
+- XML resources,
+- Gradle scripts,
+- source directory paths,
+- native/JNI bindings,
+- documentation.
+
+Manual rename instructions are easy to get wrong. A template generator should perform these changes deterministically.
+
+## Generator responsibilities
+
+A reliable generator should:
+
+1. copy the template,
+2. rewrite package and app names,
+3. move source directories,
+4. exclude local-only files,
+5. remove template-only tools,
+6. verify the generated project can build.
 
 ## ComposeTemplate approach
 
-`CreateNewAppPlugin` automates project generation:
+ComposeTemplate implements generation through a Gradle task exposed by `CreateNewAppPlugin`.
 
-- copies the template to a sibling directory,
-- rewrites package name and app name,
-- moves source directories,
-- removes template-specific generator code,
-- excludes `.git`, `.gradle`, `.idea`, `local.properties`, `secrets.properties`, and build outputs.
+```bash
+./gradlew create-new-app -Pargs='com.example.myapp,MyNewApp' -q --console=plain
+```
 
-## Takeaway
+It excludes files such as `.git`, `.gradle`, `.idea`, `local.properties`, and `secrets.properties` so personal or local state does not leak into generated apps.
 
-A reliable template generator is a product feature, not a convenience script.
+## Native package rename issue
+
+JNI methods often depend on package-derived names. ComposeTemplate avoids fragile convention-based JNI names by using `RegisterNatives`, allowing generated package names to keep working.
+
+## Common mistakes
+
+- Copying local secret files.
+- Leaving generator plugins inside generated apps.
+- Rewriting Kotlin files but not XML or Gradle files.
+- Not testing the generated app in CI.
+
+## Production checklist
+
+- [ ] Generated app builds from a clean checkout.
+- [ ] Package name and source paths match.
+- [ ] Local files are excluded.
+- [ ] Template-only generator code is removed.
+- [ ] Native bindings survive rename.
+- [ ] CI runs create-new-app smoke tests.
+
+## Summary
+
+A template generator is a build tool, not a script. ComposeTemplate uses Gradle to make app generation repeatable, reviewable, and testable.

--- a/docs/tech-blog/template-engineering/ci-android-template-repositories.md
+++ b/docs/tech-blog/template-engineering/ci-android-template-repositories.md
@@ -1,24 +1,71 @@
 # CI for Android Template Repositories: Testing Generated Apps
 
-A template repository needs a different CI mindset than a normal app repository.
+## Who this article is for
 
-## Problem
+This article is for maintainers of Android templates, starter kits, and platform repositories.
 
-If CI only builds the current app, generator regressions can slip through. A template must prove that the output it generates still works.
+## What you will learn
 
-## ComposeTemplate approach
+- Why normal app CI is not enough for templates
+- What a template smoke test should cover
+- How generator regressions slip through
+- How ComposeTemplate validates generated output
 
-The CI pipeline checks:
+## The problem
 
-- ktlint and detekt,
+A normal app repository can ask:
+
+```text
+Does this app build and pass tests?
+```
+
+A template repository must also ask:
+
+```text
+Does the app generated from this template build and behave correctly?
+```
+
+If CI only validates the template source, the generator can break unnoticed.
+
+## ComposeTemplate CI model
+
+ComposeTemplate’s CI validates:
+
+- formatting with ktlint,
+- static analysis with detekt,
 - unit tests,
-- debug and release builds,
+- debug and release assembly,
 - feature scaffold generation,
-- database-backed feature generation,
-- generated feature compilation,
+- database-backed scaffold generation,
+- compilation of scaffolded feature modules,
 - create-new-app execution,
-- local secret exclusion in generated apps.
+- generated app exclusion of local files.
 
-## Takeaway
+## Why generated output matters
 
-For a template repository, CI must test the template output, not only the template source.
+The generated app is what users actually consume. If it contains `local.properties`, stale package names, broken native bindings, or missing Gradle wiring, the template has failed.
+
+## Smoke tests vs full validation
+
+A smoke test is intentionally lightweight. It should catch high-value failures quickly. It does not replace deeper generated-app builds, security scans, or benchmark runs.
+
+## Common mistakes
+
+- Only building the template app.
+- Not testing scaffolded features.
+- Not checking local file exclusions.
+- Not testing release assembly.
+- Allowing generator behavior to change without review.
+
+## Production checklist
+
+- [ ] CI builds the template app.
+- [ ] CI runs unit tests and static analysis.
+- [ ] CI runs feature scaffolding.
+- [ ] CI runs create-new-app.
+- [ ] CI verifies generated apps do not include local secrets.
+- [ ] CI compiles generated/scaffolded modules.
+
+## Summary
+
+Template CI must test the product of the template: generated projects. ComposeTemplate treats generator behavior as production behavior and validates it in CI.

--- a/docs/tech-blog/template-engineering/feature-scaffolding-clean-architecture.md
+++ b/docs/tech-blog/template-engineering/feature-scaffolding-clean-architecture.md
@@ -1,19 +1,42 @@
 # Feature Scaffolding for Clean Architecture
 
-Feature scaffolding reduces the repetitive work of creating new Clean Architecture feature modules.
+## Who this article is for
 
-## Problem
+This article is for teams that repeatedly create similar feature modules and want to reduce boilerplate without weakening architecture.
 
-Adding a feature manually means creating modules, Gradle files, routes, ViewModels, UiState/Event classes, Hilt modules, and app wiring. Missing one step can break the build.
+## What you will learn
+
+- What feature scaffolding should generate
+- How scaffolding supports Clean Architecture
+- Why generated code should be treated as a starting point
+- Common scaffold-generator mistakes
+
+## The problem
+
+Adding a feature in a modular Clean Architecture project is repetitive. A developer may need to create:
+
+- `data`, `domain`, `navigation`, and `presentation` modules,
+- Gradle files,
+- settings entries,
+- route objects,
+- screen providers,
+- ViewModels,
+- state and event models,
+- Hilt modules,
+- optional database classes.
+
+Manual work is slow and error-prone.
 
 ## ComposeTemplate approach
+
+ComposeTemplate provides:
 
 ```bash
 ./gradlew scaffoldFeature -PfeatureName=settings
 ./gradlew scaffoldFeature -PfeatureName=settings -PwithDatabase=true
 ```
 
-## Generated structure
+The generated feature follows the same module structure used by existing features:
 
 ```text
 feature/settings/
@@ -23,6 +46,29 @@ feature/settings/
 └── presentation/
 ```
 
-## Takeaway
+## Why scaffolding helps
 
-Scaffolding makes the intended architecture easy to follow.
+Scaffolding makes the intended architecture the easiest path. Instead of asking developers to remember every convention, the generator creates a consistent baseline.
+
+## Generated code is not final code
+
+Scaffolded code should compile and demonstrate the pattern. Developers should still adapt it to actual domain behavior, UI requirements, validation rules, and data sources.
+
+## Common mistakes
+
+- Generating too much business logic.
+- Generating code that does not compile.
+- Forgetting settings or app module wiring.
+- Creating scaffolds that differ from real project conventions.
+
+## Production checklist
+
+- [ ] Scaffolded feature compiles.
+- [ ] Generated modules follow architecture boundaries.
+- [ ] Optional database scaffold is valid.
+- [ ] CI tests scaffold output.
+- [ ] Generated code is documented as a starting point.
+
+## Summary
+
+Feature scaffolding improves developer experience by turning architecture conventions into executable tooling. ComposeTemplate uses scaffolding to make correct feature creation faster and less error-prone.


### PR DESCRIPTION
## Summary
- Resolve the PR #10 conflict by starting from the latest `main` branch
- Deepen all 21 ComposeTemplate Tech Blog articles in a single PR
- Replace the previous upcoming/summary split with a complete deep-dive series index
- Add developer-focused explanations, mental models, implementation notes, common mistakes, production checklists, and summaries across architecture, build system, template engineering, security, performance, quality, and DX topics

## Included article groups
- Architecture
- Build System
- Template Engineering
- Security
- Performance
- Quality and Developer Experience

## Notes
- PR #10 was based on a branch that conflicted with `main`; this PR is created from latest `main` and carries the full final blog content in one place.
- `mkdocs.yml` already contains the Tech Blog Series navigation on `main`, so this PR focuses on replacing and deepening the article content.

## Testing
- Not run locally in this environment.