### PR TITLE
Clean up documentation landing and onboarding flow

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,63 +1,67 @@
 # Getting Started
 
-This page explains how to clone ComposeTemplate and generate your own Android application.
+This page is the short onboarding path for ComposeTemplate.
+
+If you want the detailed workflow, use [Generate a New App](guides/generate-new-app.md).
 
 ## Requirements
 
 - Android Studio Ladybug or newer
 - JDK 17+
 - Android SDK
-- Gradle wrapper
-- CMake / NDK support
 - Git
+- CMake / NDK support if native secret obfuscation is enabled
 
 Use the repository Gradle wrapper instead of a locally installed Gradle binary.
 
-## Clone
+## 1. Clone the template
 
 ```bash
 git clone https://github.com/mustafayigitt/ComposeTemplate.git
 cd ComposeTemplate
 ```
 
-## Generate a new app
+## 2. Generate your app
 
 ```bash
 ./gradlew create-new-app -Pargs='com.example.myapp,MyNewApp' -q --console=plain
+cd ../MyNewApp
 ```
 
-The command creates a sibling project at `../MyNewApp`.
+The generated project is created as a sibling directory.
 
-## Configure secrets
+## 3. Configure secrets
 
-Create `secrets.properties` in the generated project root:
+Copy the example file and replace placeholder values:
 
-```properties
-API_KEY_DEBUG="your_debug_key"
-API_KEY_RELEASE="your_release_key"
-BASE_URL_DEBUG="https://api-debug.test.com/"
-BASE_URL_RELEASE="https://api.test.com/"
-STORE_FILE="release.keystore"
-KEY_ALIAS="your_key_alias"
-KEY_PASSWORD="your_key_password"
-STORE_PASSWORD="your_store_password"
-XOR_MASK="your_custom_mask_with_24_plus_chars"
-EXPECTED_SIGNATURE_HASH="your_release_sha256_hex_with_or_without_colons"
-NATIVE_RUNTIME_CHECKS_ENABLED=true
-CERTIFICATE_PINNING_ENABLED=false
-CERTIFICATE_PINS=""
+```bash
+cp secrets.properties.example secrets.properties
 ```
 
-## Validate and build
+Then review [Secret Management](security/secret-management.md) and [Validate Secrets](template-tools/validate-secrets.md).
+
+## 4. Validate the project
+
+Run the common local verification set:
 
 ```bash
 ./gradlew validateSecrets
 ./gradlew ktlintCheck detekt testDebugUnitTest assembleDebug :app:assembleRelease
 ```
 
-## Scaffold a feature
+## 5. Optional: scaffold a feature
 
 ```bash
 ./gradlew scaffoldFeature -PfeatureName=settings
 ./gradlew scaffoldFeature -PfeatureName=settings -PwithDatabase=true
 ```
+
+For details, read [Scaffold a Feature](guides/scaffold-feature.md).
+
+## Next reading
+
+1. [Project Philosophy](project-philosophy.md)
+2. [Generate a New App](guides/generate-new-app.md)
+3. [Architecture Overview](architecture/overview.md)
+4. [Convention Plugins](build-system/gradle-convention-plugins.md)
+5. [Release Readiness](guides/release-readiness.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,16 @@ ComposeTemplate is a production-grade Jetpack Compose template generator for sta
 
 It is not only a sample app. It is a working template that can generate a new project with your package name, app name, module graph, build conventions, and quality gates.
 
+## Start here
+
+If you are new to the project, follow this path:
+
+1. [Getting Started](getting-started.md)
+2. [Generate a New App](guides/generate-new-app.md)
+3. [Configure Secrets](security/secret-management.md)
+4. [Run Release Readiness Checks](guides/release-readiness.md)
+5. [Scaffold a Feature](guides/scaffold-feature.md)
+
 ## What ComposeTemplate provides
 
 ComposeTemplate brings together the foundations most Android projects eventually need:
@@ -60,38 +70,30 @@ Generate a new app:
 cd ../MyNewApp
 ```
 
-Create `secrets.properties`, then validate and build:
+Validate after configuring secrets:
 
 ```bash
 ./gradlew validateSecrets
 ./gradlew ktlintCheck detekt testDebugUnitTest assembleDebug :app:assembleRelease
 ```
 
-## Documentation paths
-
-Start with these pages:
-
-1. [Getting Started](getting-started.md)
-2. [Project Philosophy](project-philosophy.md)
-3. [Generate a New App](guides/generate-new-app.md)
-4. [Architecture Overview](architecture/overview.md)
-5. [Convention Plugins](build-system/convention-plugins.md)
-6. [Secret Management](security/secret-management.md)
-7. [Release Readiness](guides/release-readiness.md)
-
-## How to read this documentation
-
-ComposeTemplate documentation is organized into four layers:
+## Documentation map
 
 | Area | Purpose |
 |---|---|
 | Guides | Complete concrete workflows |
-| Architecture | Explain design decisions and module boundaries |
-| Reference | Look up tasks, modules, plugins, and configuration |
-| Tech Blog | Read long-form engineering deep dives |
+| Architecture | Design decisions and module boundaries |
+| Build System | Convention plugins, version catalog, static analysis, CI |
+| Security | Secrets, runtime integrity, pinning, release hardening |
+| Template Tools | Generator and scaffold task references |
+| Quality | Testing, release readiness, performance foundations |
+| Reference | Task and module lookup |
+| Tech Blog | Long-form engineering deep dives |
 
-If you want to use the template quickly, start with Guides.
+## Recommended deep dives
 
-If you want to understand why the project is structured this way, read Architecture and Build System.
-
-If you want publishable engineering articles, read the Tech Blog series.
+- [Architecture Overview](architecture/overview.md)
+- [Feature Modularization](architecture/feature-modularization.md)
+- [Gradle Convention Plugins](build-system/gradle-convention-plugins.md)
+- [Secret Management](security/secret-management.md)
+- [Tech Blog Series](tech-blog/index.md)


### PR DESCRIPTION
## Summary

This PR cleans up the public documentation/wiki experience after the main docs rebuild.

## Changes

- Simplifies and improves `docs/index.md` as a clearer landing page
- Adds a stronger "Start here" path for new users
- Cleans up `docs/getting-started.md` to avoid duplicating the full generated-app guide
- Replaces the long inline secrets example with a safer `secrets.properties.example` flow
- Fixes internal links to the actual convention plugin documentation path

## Why

The published site still showed some older short pages while GitHub Pages deployment catches up. Reviewing the wiki surfaced that the landing and onboarding pages should be cleaner and less repetitive now that detailed Guides and Reference sections exist.

## Validation

- Documentation-only change
- MkDocs navigation already references the affected pages
- Internal links corrected for existing docs paths