### PR TITLE
feat: AppInitializer multibinding so optional modules become plug-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,20 @@ jobs:
 
       - name: Create local.properties and secrets.properties
         run: |
-          # (diğer job'lardaki aynı blok)
+          echo "STORE_FILE=debug.keystore" > local.properties
+          echo "API_KEY_DEBUG=\"debug_secret_value\"" > secrets.properties
+          echo "API_KEY_RELEASE=\"release_secret_value\"" >> secrets.properties
+          echo "BASE_URL_DEBUG=\"https://example.com/\"" >> secrets.properties
+          echo "BASE_URL_RELEASE=\"https://example.com/\"" >> secrets.properties
+          echo "KEY_ALIAS=\"androiddebugkey\"" >> secrets.properties
+          echo "KEY_PASSWORD=\"android\"" >> secrets.properties
+          echo "STORE_PASSWORD=\"android\"" >> secrets.properties
+          echo "XOR_MASK=\"ci_mask_value_with_24_chars_minimum\"" >> secrets.properties
+          echo "EXPECTED_SIGNATURE_HASH=\"53017D6F6B5A861B3096D18257D5C91F0588287BC587F12C35767D362EF0A3A8\"" >> secrets.properties
+          echo "NATIVE_RUNTIME_CHECKS_ENABLED=true" >> secrets.properties
+          echo "CERTIFICATE_PINNING_ENABLED=false" >> secrets.properties
+          echo "CERTIFICATE_PINS=\"\"" >> secrets.properties
+          echo "MIN_VERSION=1" >> secrets.properties
 
       - name: Delete optional modules
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,47 @@ jobs:
       - name: Assemble debug and release
         run: ./gradlew assembleDebug :app:assembleRelease
 
+  plug-out:
+    name: Plug-out (optional modules removed)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Create local.properties and secrets.properties
+        run: |
+          # (diğer job'lardaki aynı blok)
+
+      - name: Delete optional modules
+        run: |
+          set -eu
+          for module in core/security; do
+            gradle_path=":$(echo "$module" | tr '/' ':')"
+            echo "Removing $gradle_path"
+            rm -rf "$module"
+            sed -i "\|include(\"$gradle_path\")|d" settings.gradle.kts
+            sed -i "\|project(\"$gradle_path\")|d" app/build.gradle.kts
+          done
+
+      - name: Verify no source references the removed modules
+        run: |
+          set -eu
+          if grep -rn "core\.security" --include="*.kt" app core feature; then
+            echo "Removed module is still referenced from Kotlin sources."
+            exit 1
+          fi
+
+      - name: Assemble debug without optional modules
+        run: ./gradlew :app:assembleDebug
+
   template-smoke:
     name: Template Smoke
     runs-on: ubuntu-latest

--- a/app/src/main/java/com/ytapps/composetemplate/App.kt
+++ b/app/src/main/java/com/ytapps/composetemplate/App.kt
@@ -1,39 +1,28 @@
 package com.ytapps.composetemplate
 
 import android.app.Application
-import com.ytapps.composetemplate.core.secrets.SecretManager
-import com.ytapps.composetemplate.core.security.DeviceIntegrityManager
-import com.ytapps.composetemplate.core.security.SecurityPolicy
+import com.ytapps.composetemplate.core.common.initializer.AppInitializer
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
+import javax.inject.Inject
 
 @HiltAndroidApp
 class App : Application() {
+    /**
+     * Startup work contributed by optional modules. The set is empty when every
+     * contributing module has been removed, so nothing here needs to change when a module
+     * is plugged out.
+     */
+    @Inject
+    lateinit var initializers: Set<@JvmSuppressWildcards AppInitializer>
+
     override fun onCreate() {
         super.onCreate()
-        SecretManager.initialize(this)
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
-        enforceClientHardeningPolicy()
-    }
-
-    private fun enforceClientHardeningPolicy() {
-        val report =
-            DeviceIntegrityManager(
-                context = this,
-                policy =
-                    SecurityPolicy(
-                        expectedPackageName = BuildConfig.APPLICATION_ID,
-                        blockOnFindings = !BuildConfig.DEBUG && SecretManager.isNativeRuntimeChecksEnabled(),
-                    ),
-            ).evaluate()
-
-        if (report.findings.isNotEmpty()) {
-            Timber.w("Client hardening findings: %s", report.findings.joinToString())
-        }
-        check(!report.isBlocked) {
-            "Client hardening policy blocked app startup: ${report.findings.joinToString()}"
-        }
+        initializers
+            .sortedBy { it.order }
+            .forEach { it.init(this) }
     }
 }

--- a/core/common/src/main/java/com/ytapps/composetemplate/core/common/initializer/AppInitializer.kt
+++ b/core/common/src/main/java/com/ytapps/composetemplate/core/common/initializer/AppInitializer.kt
@@ -1,0 +1,36 @@
+package com.ytapps.composetemplate.core.common.initializer
+
+import android.app.Application
+
+/**
+ * Contract for startup work contributed by an optional module.
+ *
+ * A module contributes its own startup logic with `@Binds @IntoSet` instead of being
+ * called explicitly from the application class. The application class only iterates the
+ * injected set, so deleting a contributing module removes its startup work without any
+ * edit in `:app`.
+ *
+ * Implementations must be side-effect free when their module is absent, and must not
+ * assume any other initializer already ran unless they declare a higher [order].
+ */
+interface AppInitializer {
+    /**
+     * Lower values run first. Only use an explicit value when the initializer depends on
+     * another one having already run.
+     */
+    val order: Int
+        get() = ORDER_DEFAULT
+
+    fun init(app: Application)
+
+    companion object {
+        /** Secrets must be ready before anything reads a secret-backed value. */
+        const val ORDER_SECRETS = 0
+
+        /** Hardening reads secret-backed flags, so it runs after secrets. */
+        const val ORDER_SECURITY = 50
+
+        /** Default slot for initializers without ordering requirements. */
+        const val ORDER_DEFAULT = 100
+    }
+}

--- a/core/common/src/main/java/com/ytapps/composetemplate/core/common/initializer/AppInitializerModule.kt
+++ b/core/common/src/main/java/com/ytapps/composetemplate/core/common/initializer/AppInitializerModule.kt
@@ -1,0 +1,19 @@
+package com.ytapps.composetemplate.core.common.initializer
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.Multibinds
+
+/**
+ * Declares the initializer multibinding as possibly empty.
+ *
+ * Without this declaration Hilt fails to build the graph when every contributing module
+ * has been deleted, which is exactly the plug-out case this architecture must support.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface AppInitializerModule {
+    @Multibinds
+    fun appInitializers(): Set<AppInitializer>
+}

--- a/core/secrets/build.gradle.kts
+++ b/core/secrets/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("composetemplate.android.library")
     id("composetemplate.android.library.native")
+    id("composetemplate.android.hilt")
 }
 
 android {

--- a/core/secrets/src/main/java/com/ytapps/composetemplate/core/secrets/initializer/SecretsInitializer.kt
+++ b/core/secrets/src/main/java/com/ytapps/composetemplate/core/secrets/initializer/SecretsInitializer.kt
@@ -1,0 +1,19 @@
+package com.ytapps.composetemplate.core.secrets.initializer
+
+import android.app.Application
+import com.ytapps.composetemplate.core.common.initializer.AppInitializer
+import com.ytapps.composetemplate.core.secrets.SecretManager
+import javax.inject.Inject
+
+/**
+ * Binds the application context into [SecretManager] at startup.
+ */
+internal class SecretsInitializer
+    @Inject
+    constructor() : AppInitializer {
+        override val order: Int = AppInitializer.ORDER_SECRETS
+
+        override fun init(app: Application) {
+            SecretManager.initialize(app)
+        }
+    }

--- a/core/secrets/src/main/java/com/ytapps/composetemplate/core/secrets/initializer/SecretsInitializerModule.kt
+++ b/core/secrets/src/main/java/com/ytapps/composetemplate/core/secrets/initializer/SecretsInitializerModule.kt
@@ -1,0 +1,16 @@
+package com.ytapps.composetemplate.core.secrets.initializer
+
+import com.ytapps.composetemplate.core.common.initializer.AppInitializer
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface SecretsInitializerModule {
+    @Binds
+    @IntoSet
+    fun bindSecretsInitializer(initializer: SecretsInitializer): AppInitializer
+}

--- a/core/security/build.gradle.kts
+++ b/core/security/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("composetemplate.android.library")
+    id("composetemplate.android.hilt")
 }
 
 android {
@@ -7,6 +8,8 @@ android {
 }
 
 dependencies {
+    implementation(project(":core:common"))
     implementation(project(":core:secrets"))
     implementation(libs.androidx.core)
+    implementation(libs.timber)
 }

--- a/core/security/src/main/java/com/ytapps/composetemplate/core/security/initializer/HardeningInitializer.kt
+++ b/core/security/src/main/java/com/ytapps/composetemplate/core/security/initializer/HardeningInitializer.kt
@@ -1,0 +1,43 @@
+package com.ytapps.composetemplate.core.security.initializer
+
+import android.app.Application
+import android.content.pm.ApplicationInfo
+import com.ytapps.composetemplate.core.common.initializer.AppInitializer
+import com.ytapps.composetemplate.core.secrets.SecretManager
+import com.ytapps.composetemplate.core.security.DeviceIntegrityManager
+import com.ytapps.composetemplate.core.security.SecurityPolicy
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * Evaluates the client hardening policy at startup and blocks launch when the device or
+ * the installed package fails the policy.
+ *
+ * Debuggability is read from the running application instead of the app module's
+ * `BuildConfig`, so this initializer stays independent of `:app`.
+ */
+internal class HardeningInitializer
+    @Inject
+    constructor() : AppInitializer {
+        override val order: Int = AppInitializer.ORDER_SECURITY
+
+        override fun init(app: Application) {
+            val isDebuggable = (app.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+            val report =
+                DeviceIntegrityManager(
+                    context = app,
+                    policy =
+                        SecurityPolicy(
+                            expectedPackageName = app.packageName,
+                            blockOnFindings = !isDebuggable && SecretManager.isNativeRuntimeChecksEnabled(),
+                        ),
+                ).evaluate()
+
+            if (report.findings.isNotEmpty()) {
+                Timber.w("[core:security] Client hardening findings: %s", report.findings.joinToString())
+            }
+            check(!report.isBlocked) {
+                "[core:security] Client hardening policy blocked app startup: ${report.findings.joinToString()}"
+            }
+        }
+    }

--- a/core/security/src/main/java/com/ytapps/composetemplate/core/security/initializer/HardeningInitializerModule.kt
+++ b/core/security/src/main/java/com/ytapps/composetemplate/core/security/initializer/HardeningInitializerModule.kt
@@ -1,0 +1,16 @@
+package com.ytapps.composetemplate.core.security.initializer
+
+import com.ytapps.composetemplate.core.common.initializer.AppInitializer
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface HardeningInitializerModule {
+    @Binds
+    @IntoSet
+    fun bindHardeningInitializer(initializer: HardeningInitializer): AppInitializer
+}


### PR DESCRIPTION
## Why

First step of making the template plug-in / plug-out: an optional module must be deletable as a folder, without editing `:app`.

Right now `App.kt` hard-wires two optional modules:

```kotlin
SecretManager.initialize(this)          // core:secrets
enforceClientHardeningPolicy()          // core:security
```

So deleting `core/security` breaks the build even though nothing else uses it. This PR removes that coupling for startup work.

## What

**New contract in `core:common`**

```kotlin
interface AppInitializer {
    val order: Int get() = ORDER_DEFAULT
    fun init(app: Application)
}
```

`order` exists because hardening reads a secret-backed flag, so secrets (`0`) must run before security (`50`). Everything else defaults to `100`.

**Contributions instead of calls**

| Module | Initializer | Order |
| --- | --- | --- |
| `core:secrets` | `SecretsInitializer` | 0 |
| `core:security` | `HardeningInitializer` | 50 |

Both are contributed with `@Binds @IntoSet`, so nobody calls them.

**`@Multibinds` empty-set declaration**

`AppInitializerModule` declares `Set<AppInitializer>` as possibly empty. Without it Hilt fails the graph when every contributor is deleted, which is exactly the plug-out case. This is the silent trap of the whole architecture, so it lands together with the contract.

**`App.kt` is now module-agnostic**

```kotlin
@Inject lateinit var initializers: Set<@JvmSuppressWildcards AppInitializer>

override fun onCreate() {
    super.onCreate()
    if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
    initializers.sortedBy { it.order }.forEach { it.init(this) }
}
```

No `core.secrets` / `core.security` import remains in `:app`.

## Behavior preserved

- Startup still blocks on a blocking hardening report (`check(!report.isBlocked)`), and findings are still logged. Messages are now prefixed with `[core:security]` so the originating module is identifiable in logs.
- `HardeningInitializer` reads debuggability from `ApplicationInfo.FLAG_DEBUGGABLE` and the package name from `app.packageName` instead of the app module's `BuildConfig`, so it no longer depends on `:app` at all.
- Timber planting stays in `App.kt`: it is not optional.

## Build wiring

- `core:secrets` and `core:security` gain the Hilt convention plugin (they now contribute bindings).
- `core:security` gains `:core:common` and `libs.timber`; its existing `:core:secrets` dependency is unchanged.

## Verification

Locally, this should now pass:

```bash
rm -rf core/security
# drop include(":core:security") from settings.gradle.kts
# drop implementation(project(":core:security")) from app/build.gradle.kts
./gradlew :app:assembleDebug
```

A CI `plug-out` job that automates exactly this is prepared separately — it could not be pushed from here because the connection lacks GitHub Actions workflow write scope.

## Not in this PR

- `core:secrets` is not independently deletable yet: `core/network/di/NetworkModule.kt` still calls `SecretManager` directly. That is a later phase.
- Optional single-valued dependencies (`ITokenRefresher`, `IAnalyticsManager`, `NetworkMonitor`, `LocaleManager`) and the `AppNavigation` host refactor are deliberately left out to keep this PR behavior-neutral.
