### PR TITLE
feat: make token refresh an optional contribution so feature:auth can be plugged out

### DIFF
--- a/core/network/src/main/java/com/ytapps/composetemplate/core/network/TokenAuthenticator.kt
+++ b/core/network/src/main/java/com/ytapps/composetemplate/core/network/TokenAuthenticator.kt
@@ -25,13 +25,17 @@ import javax.inject.Singleton
  * Thread Safety:
  * - Uses synchronized block to prevent multiple simultaneous token refresh requests
  * - Checks if token was already refreshed by another thread
+ *
+ * Optional refreshing:
+ * - Token refreshing is contributed by another module and may be absent entirely.
+ * - When absent, a 401 is simply not retried; the network layer stays functional.
  */
 @Singleton
 internal class TokenAuthenticator
     @Inject
     constructor(
         private val prefs: IPreferencesManager,
-        private val tokenRefresher: Lazy<ITokenRefresher>,
+        private val tokenRefreshers: Lazy<Set<@JvmSuppressWildcards ITokenRefresher>>,
     ) : Authenticator {
         private val lock = Any()
 
@@ -70,25 +74,44 @@ internal class TokenAuthenticator
                 return if (!newToken.isNullOrEmpty()) {
                     buildRequestWithToken(response.request, newToken)
                 } else {
-                    // Token refresh failed, don't retry
+                    // Token refresh failed or is not available, don't retry
                     null
                 }
             }
         }
 
-        private fun refreshToken(): String? =
-            try {
+        private fun refreshToken(): String? {
+            val refresher = resolveRefresher() ?: return null
+            return try {
                 // Note: runBlocking is acceptable here because:
                 // 1. Authenticator.authenticate() is called on OkHttp's dispatcher thread, not the main thread
                 // 2. The token refresh is a blocking operation by nature (we need the token before proceeding)
                 // 3. This is the standard pattern for OkHttp Authenticator with suspend functions
                 runBlocking {
-                    tokenRefresher.get().refreshToken().getOrNull()
+                    refresher.refreshToken().getOrNull()
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Token refresh failed")
                 null
             }
+        }
+
+        /**
+         * Resolves the single installed refresher, or null when the contributing module is
+         * absent. Resolution is deferred until a 401 actually happens, which also keeps the
+         * refresher out of the object graph that builds this authenticator.
+         */
+        private fun resolveRefresher(): ITokenRefresher? {
+            val refreshers = tokenRefreshers.get()
+            if (refreshers.isEmpty()) {
+                Timber.d("No token refresher is installed; a 401 will not be retried.")
+                return null
+            }
+            check(refreshers.size == 1) {
+                "Exactly one ITokenRefresher may be contributed, but found ${refreshers.size}."
+            }
+            return refreshers.first()
+        }
 
         private fun buildRequestWithToken(
             request: Request,

--- a/core/network/src/main/java/com/ytapps/composetemplate/core/network/di/TokenRefresherModule.kt
+++ b/core/network/src/main/java/com/ytapps/composetemplate/core/network/di/TokenRefresherModule.kt
@@ -1,0 +1,26 @@
+package com.ytapps.composetemplate.core.network.di
+
+import com.ytapps.composetemplate.core.common.ITokenRefresher
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.Multibinds
+
+/**
+ * Declares token refreshing as an optional capability.
+ *
+ * The network layer must build and serve requests even when no module provides token
+ * refreshing, so the set is declared here as possibly empty. Without this declaration
+ * Hilt fails the graph as soon as the contributing feature is removed, which is exactly
+ * the plug-out case this template must support.
+ *
+ * At most one refresher is expected. The set is only a mechanism for "zero or one",
+ * because Dagger's optional bindings would require `java.util.Optional`, which is not
+ * available at this project's `minSdk`.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface TokenRefresherModule {
+    @Multibinds
+    fun tokenRefreshers(): Set<ITokenRefresher>
+}

--- a/core/network/src/test/java/com/ytapps/composetemplate/core/network/TokenAuthenticatorTest.kt
+++ b/core/network/src/test/java/com/ytapps/composetemplate/core/network/TokenAuthenticatorTest.kt
@@ -25,8 +25,7 @@ internal class TokenAuthenticatorTest {
     fun setUp() {
         preferencesManager = mockk()
         tokenRefresher = mockk()
-        val lazyTokenRefresher = Lazy { tokenRefresher }
-        authenticator = TokenAuthenticator(preferencesManager, lazyTokenRefresher)
+        authenticator = TokenAuthenticator(preferencesManager, refreshers(tokenRefresher))
     }
 
     @Test
@@ -48,6 +47,19 @@ internal class TokenAuthenticatorTest {
 
             assertThat(result).isNull()
         }
+
+    @Test
+    fun `given no refresher is contributed when unauthorized then does not retry`() =
+        runTest {
+            every { preferencesManager.getAccessToken() } returns "old-token"
+            authenticator = TokenAuthenticator(preferencesManager, refreshers())
+
+            val result = authenticator.authenticate(null, unauthorizedResponse("https://example.com/protected"))
+
+            assertThat(result).isNull()
+        }
+
+    private fun refreshers(vararg refreshers: ITokenRefresher): Lazy<Set<ITokenRefresher>> = Lazy { refreshers.toSet() }
 
     private fun unauthorizedResponse(url: String): Response =
         Response

--- a/feature/auth/data/src/main/java/com/ytapps/composetemplate/feature/auth/data/di/BinderModule.kt
+++ b/feature/auth/data/src/main/java/com/ytapps/composetemplate/feature/auth/data/di/BinderModule.kt
@@ -7,6 +7,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -14,6 +15,11 @@ internal abstract class BinderModule {
     @Binds
     abstract fun bindAuthRepository(authRepository: AuthRepository): IAuthRepository
 
+    /**
+     * Contributed into a set so the network layer keeps working when this feature is
+     * removed. Nothing outside this module needs to know who refreshes tokens.
+     */
     @Binds
+    @IntoSet
     abstract fun bindTokenRefresher(authRepository: AuthRepository): ITokenRefresher
 }


### PR DESCRIPTION
Phase 2 of the plug-out work. Phase 1 solved *multiple* contributions (`Set<AppInitializer>`); this one solves a *singular* dependency that may be absent.

## Why

`ITokenRefresher` is declared in `core:common`, but the only implementation lives in `feature:auth:data`:

```kotlin
@Binds
abstract fun bindTokenRefresher(authRepository: AuthRepository): ITokenRefresher
```

`TokenAuthenticator` in `core:network` injects it as a required dependency, so deleting `feature/auth` makes the Hilt graph fail in a module that has nothing to do with auth. A network layer should not stop compiling because a feature was removed.

## Why not `@BindsOptionalOf`

That was the plan, and it is the idiomatic answer, but Dagger's optional bindings require `java.util.Optional` (API 24) or Guava's `Optional`. This project targets **minSdk 23** and does not enable core library desugaring, so `Optional` would either force a desugaring setup across every module or drag in Guava. Neither is worth it for one binding.

So the same mechanism as phase 1 is reused, deliberately narrowed to "zero or one":

```kotlin
@Multibinds
fun tokenRefreshers(): Set<ITokenRefresher>
```

`TokenRefresherModule` lives in `core:network`, next to the consumer, and documents that the set exists only to express optionality. If desugaring is ever enabled, this collapses into `@BindsOptionalOf` without touching call sites.

## What changed

- `feature:auth:data` contributes with `@Binds @IntoSet` instead of a required `@Binds`. `IAuthRepository` binding is untouched.
- `TokenAuthenticator` now injects `Lazy<Set<@JvmSuppressWildcards ITokenRefresher>>`.
- New `resolveRefresher()` returns null and logs at debug level when the set is empty, so a 401 simply is not retried.
- More than one contribution fails loudly (`check(refreshers.size == 1)`) rather than picking an arbitrary element.

## Why `Lazy` is still there

The original `dagger.Lazy` was not a performance trick, it breaks a real cycle:

```
AuthRepository -> Retrofit -> OkHttpClient -> TokenAuthenticator -> ITokenRefresher -> AuthRepository
```

Injecting `Set<ITokenRefresher>` directly would recreate that cycle, so the wrapper became `Lazy<Set<...>>` rather than `Set<Lazy<...>>`. Resolution still happens on the first 401, not at graph construction.

## Verification

The absent case is now a unit test rather than a claim:

```kotlin
@Test
fun `given no refresher is contributed when unauthorized then does not retry`()
```

The two existing tests are unchanged in intent; they now build the authenticator through a small `refreshers(vararg ...)` helper.

## Behavior

Unchanged when `feature:auth` is present: same refresh, same retry cap, same concurrency guard, same `/auth/refresh` short-circuit. When absent, 401s propagate to the caller and `safeCall` maps them as usual.

## Not in this PR

`feature/auth` is still not deletable end to end: `:app` wires its navigation and screen providers. That is phase 3 (`AppChrome` / `NavigationObserver` host refactor), after which `feature/auth` can join the CI `plug-out` delete list. This PR removes the *core-layer* blocker only, so the CI job is intentionally unchanged.
