### PR TITLE
chore: raise minSdk from 23 to 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ New here? Read [08 - Getting Started](wiki/08-getting-started.md) for setup, req
 
 ## Requirements
 
-JDK 17, Android SDK (compileSdk 37 / targetSdk 36 / minSdk 23), NDK 27.0.12077973 with CMake. Always use the Gradle wrapper — this is a composite build.
+JDK 17, Android SDK (compileSdk 37 / targetSdk 36 / minSdk 26), NDK 27.0.12077973 with CMake. Always use the Gradle wrapper — this is a composite build.
 
 ## Contributing
 

--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -117,10 +117,13 @@ build-logic/
 All dependencies and versions are managed in `gradle/libs.versions.toml`.
 
 ### Key SDK Versions
-- **minSdk**: 23
+- **minSdk**: 26
 - **compileSdk**: 37
 - **targetSdk**: 36
 - **Kotlin**: 2.0.21
+
+The `minSdk` baseline is Android 8.0 (Oreo). It is read from the catalog by every
+convention plugin, so changing it there changes it for all ~48 modules at once.
 
 ## 🔧 Configuring Metrics
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # SDK versions
-minSdk = "23"
+minSdk = "26"
 compileSdk = "37"
 targetSdk = "36"
 ndk = "27.0.12077973"

--- a/wiki/01-module-topology.md
+++ b/wiki/01-module-topology.md
@@ -44,7 +44,7 @@ Each feature tier plugin encodes what that layer is allowed to depend on — thi
 
 | Area | Version |
 | --- | --- |
-| minSdk / targetSdk / compileSdk | 23 / 36 / 37 |
+| minSdk / targetSdk / compileSdk | 26 / 36 / 37 |
 | NDK | 27.0.12077973 |
 | Kotlin | 2.0.21 |
 | AGP | 9.2.1 |
@@ -58,6 +58,8 @@ Each feature tier plugin encodes what that layer is allowed to depend on — thi
 | Coil | 3.4.0 |
 | Detekt / ktlint plugin | 1.23.8 / 14.2.0 |
 | Test stack | JUnit 4.13.2, MockK 1.14.11, Truth 1.4.5, coroutines-test 1.11.0 |
+
+Every module reads `minSdk`, `targetSdk` and `compileSdk` from this catalog through a convention plugin — no module declares them itself, so the baseline moves in one edit. The reasoning behind the Android 8.0 baseline is recorded in [07 - Risks](07-risks-and-gaps.md#baseline-decision-log).
 
 Note: the catalog carries both `converter-gson` and `kotlinx-serialization-core` — see [03 - Network](03-network-and-auth.md).
 

--- a/wiki/07-risks-and-gaps.md
+++ b/wiki/07-risks-and-gaps.md
@@ -34,6 +34,48 @@ Findings from reading the code, ordered by practical impact. Each item is an obs
 | 16 | `config` module is local-only | `IConfigManager` + `LocalConfigProvider`; no remote-config backend, so runtime flags require a release |
 | 17 | Benchmarks and baseline profiles never run in CI | Performance infrastructure exists but is unmeasured |
 
+## Baseline decision log
+
+Decisions that constrain the whole template and are easy to reverse accidentally.
+
+### `minSdk` is 26 (Android 8.0, Oreo)
+
+The template previously shipped `minSdk 23`. That number was never load-bearing:
+the repository contains no `@RequiresApi` or `@TargetApi` annotation, and all three
+runtime `SDK_INT` checks already guard higher levels — `Build.VERSION_CODES.S` (31)
+for dynamic color in `Theme.kt`, and `Build.VERSION_CODES.P` (28) twice in
+`DeviceIntegrityManager` for `signingInfo`. Raising the baseline therefore required
+zero source changes and removed zero code.
+
+What the Oreo baseline buys:
+
+| Available without desugaring | Since |
+| --- | --- |
+| `java.util.Optional`, `java.util.function`, `Stream` | API 24 |
+| **`java.time`** (the reason 26 was chosen over 24) | API 26 |
+| Adaptive icons, notification channels as the native path | API 26 |
+
+Consequences to keep in mind:
+
+- **Core library desugaring is deliberately not enabled.** No convention plugin sets
+  `isCoreLibraryDesugaringEnabled`; `AndroidLibraryConventionPlugin` only sets
+  Java 17 source/target compatibility. At API 26 the features that desugaring
+  usually provides are already present, so the extra D8 step, the
+  `coreLibraryDesugaring` dependency and its R8 interaction are all avoided.
+- **Lowering `minSdk` again is one line** in `gradle/libs.versions.toml`, but below
+  API 26 any `java.time` usage starts requiring desugaring, and below API 24 the
+  same is true of `Optional`. This is why Dagger's `@BindsOptionalOf` was not used
+  for optional dependencies: it requires `java.util.Optional`, which was unavailable
+  at the old baseline. The template uses a possibly-empty `@Multibinds` set instead,
+  which works at any API level and stays uniform with `Set<AppInitializer>`.
+
+### Optionality is expressed with multibindings, not `Optional`
+
+Optional collaborators are declared as a possibly-empty `Set<T>` via `@Multibinds`
+and consumed as `Lazy<Set<T>>` where a dependency cycle has to stay broken (see
+`TokenAuthenticator`). One mechanism covers both "zero or one" and "zero or many",
+so the template teaches a single pattern rather than two.
+
 ## Suggested remediation order
 
 1. Make `scaffoldFeature` fail loudly when it cannot wire `settings.gradle.kts` or `app/build.gradle.kts` (item 1).

--- a/wiki/08-getting-started.md
+++ b/wiki/08-getting-started.md
@@ -7,9 +7,13 @@ Every command and key below was verified against the Gradle plugins and CI workf
 | Requirement | Source of truth |
 | --- | --- |
 | JDK 17 | `.github/workflows/ci.yml` (temurin 17) |
-| Android SDK: compileSdk 37, targetSdk 36, minSdk 23 | `gradle/libs.versions.toml` |
+| Android SDK: compileSdk 37, targetSdk 36, minSdk 26 | `gradle/libs.versions.toml` |
 | NDK 27.0.12077973 + CMake | version catalog + `core/secrets` |
 | Gradle wrapper (do not use a system Gradle) | composite build with `includeBuild("build-logic")` |
+
+The app targets Android 8.0 (API 26) and newer. Lowering that baseline is a one-line
+change in the version catalog, but read the [baseline decision log](07-risks-and-gaps.md#baseline-decision-log)
+first — some of the template's Java-API assumptions depend on it.
 
 ## 1. Generate your app
 
@@ -89,6 +93,7 @@ After scaffolding you still need to:
 - [ ] `scanApkForSecrets` clean on the release artifact
 - [ ] `hardeningReport` reviewed; pinning decision made with a rotation plan
 - [ ] Real auth refresh endpoint implemented behind `ITokenRefresher`
+- [ ] `minSdk` reviewed against your own audience before the first release
 - [ ] Sample features (`detail`, design-system catalog) removed or adapted
 - [ ] CI secrets configured as environment variables
 - [ ] App name, icon, locales and store metadata updated

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -13,7 +13,7 @@ This wiki is the **single documentation source** for ComposeTemplate. It is writ
 | 04 | [Secrets, Security and Hardening](04-secrets-and-hardening.md) | NDK/JNI secret pipeline and Gradle guardrails |
 | 05 | [Generator and Scaffolding Tooling](05-generator-and-scaffolding.md) | `scaffoldFeature`, `create-new-app` |
 | 06 | [Quality, Tests and CI](06-quality-tests-ci.md) | Unit tests, four CI jobs, template smoke test |
-| 07 | [Risks, Gaps and Open Questions](07-risks-and-gaps.md) | 17 findings with a remediation order |
+| 07 | [Risks, Gaps and Open Questions](07-risks-and-gaps.md) | 17 findings, a remediation order and the baseline decision log |
 | 08 | [Getting Started](08-getting-started.md) | Commands and secret keys taken from the build |
 
 Reading order: start with 00 for the mental model, then 01–06 for subsystems, and read 07 before making changes.
@@ -28,7 +28,7 @@ Reading order: start with 00 for the mental model, then 01–06 for subsystems, 
 | License | Apache-2.0 |
 | Gradle modules | ~48 |
 | Convention plugins | 17 |
-| minSdk / targetSdk / compileSdk | 23 / 36 / 37 |
+| minSdk / targetSdk / compileSdk | 26 / 36 / 37 |
 | Kotlin / AGP / KSP | 2.0.21 / 9.2.1 / 2.0.21-1.0.28 |
 
 ## One-paragraph summary


### PR DESCRIPTION
Raises the template baseline from Android 6.0 (Marshmallow) to **Android 8.0 (Oreo)**.

## Why 26 and not 24

Android Studio's current default is 24, but 24 is the weaker stopping point for this repo:

| Baseline | Available without core library desugaring |
| --- | --- |
| 24 | `java.util.Optional`, `java.util.function`, `Stream` |
| **26** | all of the above **plus `java.time`**, adaptive icons, notification channels as the native path |

The template has no date/time layer today. If one is ever added at `minSdk 24`, the core library desugaring discussion comes straight back. Choosing 26 closes that door permanently. A baseline is also far easier to lower than to raise: dropping back down is one line in the version catalog, while raising it after users have shipped is not.

## Why this is a safe change

`minSdk 23` was never load-bearing here. Verified against the source:

- `@RequiresApi` / `@TargetApi` — **0 occurrences** in the repository.
- `Build.VERSION.SDK_INT` — **3 occurrences**, all guarding levels *above* 26:
  - `core/ui/.../theme/Theme.kt` → `>= Build.VERSION_CODES.S` (31), dynamic color
  - `core/security/.../DeviceIntegrityManager.kt` → `>= Build.VERSION_CODES.P` (28), twice, for `signingInfo`
  - `core/secrets/src/main/cpp/native-lib.cpp` → reads `SDK_INT` over JNI with no threshold

So no guard becomes dead code and nothing was deleted. No dependency forced the old value either — Room 2.8, Coil 3, Compose BOM 2026.05 and Navigation3 all support 21+.

## What changed

One functional line:

```diff
-minSdk = "23"
+minSdk = "26"
```

Every module reads `minSdk` from the catalog through `AndroidApplicationConventionPlugin`, `AndroidLibraryConventionPlugin` and `BaselineProfileGeneratorConventionPlugin`, plus `benchmark/build.gradle.kts` directly. No module declares it itself, so all ~48 modules move together and no build file needed editing.

The rest is documentation that stated the old number:

- `README.md` — requirements line
- `build-logic/README.md` — key SDK versions
- `wiki/README.md` — source-of-truth table
- `wiki/01-module-topology.md` — version catalog table
- `wiki/08-getting-started.md` — toolchain table + a first-release checklist item to review `minSdk` against your own audience

## New: baseline decision log in the wiki

`wiki/07-risks-and-gaps.md` gains a **Baseline decision log** section recording *why* 26, why core library desugaring is deliberately still off, and what breaks if someone lowers the baseline again.

It also documents the related DI consequence: Dagger's `@BindsOptionalOf` requires `java.util.Optional` (API 24), which is why the optional-dependency work uses a possibly-empty `@Multibinds` set consumed as `Lazy<Set<T>>` instead. That mechanism works at any API level and stays uniform with `Set<AppInitializer>`, so it is kept even though API 26 would now technically permit `Optional`. Without this note the next reader would reasonably assume `@BindsOptionalOf` was simply overlooked.

## Not in this PR

- Core library desugaring stays off — at API 26 it buys nothing here, and it would add a D8 step, a runtime dependency and R8 interaction that cannot be plugged out.
- No `java.time` adoption yet. This PR only makes it possible.
- No change to the optional-dependency mechanism itself; see #18.

## Review focus

CI should be fully green with no source changes. The interesting jobs are `Assemble Debug + Release` (NDK/CMake picking up the new `minSdk` for all ABIs) and `Template Smoke` (generated app and generated feature inherit the new baseline).