### PR TITLE
feat: fail the build when :app imports a pluggable module

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -83,5 +83,9 @@ gradlePlugin {
             id = "composetemplate.baseline.profile.generator"
             implementationClass = "com.ytapps.composetemplate.convention.BaselineProfileGeneratorConventionPlugin"
         }
+        register("appModuleBoundary") {
+            id = "composetemplate.app.boundary"
+            implementationClass = "com.ytapps.composetemplate.convention.AppModuleBoundaryPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/AndroidApplicationConventionPlugin.kt
@@ -16,6 +16,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply("com.android.application")
                 apply("composetemplate.static.analysis")
+                apply("composetemplate.app.boundary")
             }
 
             extensions.configure<ApplicationExtension> {

--- a/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/AppModuleBoundaryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/AppModuleBoundaryPlugin.kt
@@ -3,7 +3,6 @@ package com.ytapps.composetemplate.convention
 import com.android.build.api.dsl.ApplicationExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 
 /**
  * Enforces plug-out criterion (2): the application module must never name a symbol that
@@ -17,41 +16,42 @@ import org.gradle.api.Task
  * The rule is an allowlist rather than a blocklist: `:app` may only reach the core modules
  * that survive every plug-out combination. A module introduced later is therefore forbidden
  * by default, without anyone having to remember to extend a list.
+ *
+ * Every lambda below is parameterless on purpose. Gradle's `Action<T>` parameters surface
+ * in Kotlin as `T.() -> Unit`, so declaring a parameter is a compile error. `matching` is
+ * the exception: it takes a `Spec<T>`, which stays an ordinary single-argument lambda.
  */
 class AppModuleBoundaryPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        // Registered with the two-argument overload on purpose. The three-argument form
-        // competes with register(String, Class, Object... constructorArgs), and Kotlin binds a
-        // trailing lambda to the vararg candidate, leaving the lambda parameter untyped.
         val boundaryCheck =
             target.tasks.register(
                 "checkAppModuleBoundary",
                 CheckAppModuleBoundaryTask::class.java,
             )
 
-        boundaryCheck.configure { task: CheckAppModuleBoundaryTask ->
-            task.group = "verification"
-            task.description = "Fails when :app imports a symbol from a module that can be plugged out"
-            task.sources.from(target.layout.projectDirectory.dir("src"))
-            task.permittedCoreModules.set(PERMITTED_CORE_MODULES)
-            task.applicationPackage.convention("")
-            task.reportFile.set(
+        boundaryCheck.configure {
+            group = "verification"
+            description = "Fails when :app imports a symbol from a module that can be plugged out"
+            sources.from(target.layout.projectDirectory.dir("src"))
+            permittedCoreModules.set(PERMITTED_CORE_MODULES)
+            reportFile.set(
                 target.layout.buildDirectory.file("reports/plugout/app-module-boundary.txt"),
+            )
+            // The namespace is assigned by the module's own build script, which runs after this
+            // plugin is applied. Reading it through a provider defers the lookup until the task
+            // input is resolved, so no afterEvaluate hook is needed.
+            applicationPackage.set(
+                target.provider {
+                    target.extensions.findByType(ApplicationExtension::class.java)
+                        ?.namespace
+                        .orEmpty()
+                },
             )
         }
 
-        // The namespace is assigned inside the module's own build script, which runs after
-        // this plugin is applied, so it can only be read once evaluation has finished.
-        target.afterEvaluate { project: Project ->
-            val namespace = project.extensions.findByType(ApplicationExtension::class.java)?.namespace
-            boundaryCheck.configure { task: CheckAppModuleBoundaryTask ->
-                task.applicationPackage.set(namespace.orEmpty())
-            }
-        }
-
         target.tasks
-            .matching { task: Task -> task.name == "preBuild" || task.name == "check" }
-            .configureEach { task: Task -> task.dependsOn(boundaryCheck) }
+            .matching { it.name == "preBuild" || it.name == "check" }
+            .configureEach { dependsOn(boundaryCheck) }
     }
 
     private companion object {

--- a/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/AppModuleBoundaryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/AppModuleBoundaryPlugin.kt
@@ -1,0 +1,53 @@
+package com.ytapps.composetemplate.convention
+
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Enforces plug-out criterion (2): the application module must never name a symbol that
+ * belongs to a module which is allowed to be deleted.
+ *
+ * Dependency injection is only half of the contract. Kotlin resolves imports before Dagger
+ * runs, so a single `import` from `:app` into an optional module turns "delete the folder"
+ * into a compile error that no binding can rescue. This plugin fails the build at that
+ * import instead of waiting for the CI plug-out job to discover it.
+ *
+ * The rule is an allowlist rather than a blocklist: `:app` may only reach the core modules
+ * that survive every plug-out combination. A module introduced later is therefore forbidden
+ * by default, without anyone having to remember to extend a list.
+ */
+class AppModuleBoundaryPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        val boundaryCheck =
+            target.tasks.register(
+                "checkAppModuleBoundary",
+                CheckAppModuleBoundaryTask::class.java,
+            ) { task ->
+                task.group = "verification"
+                task.description = "Fails when :app imports a symbol from a module that can be plugged out"
+                task.sources.from(target.layout.projectDirectory.dir("src"))
+                task.permittedCoreModules.set(PERMITTED_CORE_MODULES)
+                task.applicationPackage.convention("")
+                task.reportFile.set(
+                    target.layout.buildDirectory.file("reports/plugout/app-module-boundary.txt"),
+                )
+            }
+
+        // The namespace is assigned inside the module's own build script, which runs after
+        // this plugin is applied, so it can only be read once evaluation has finished.
+        target.afterEvaluate { project ->
+            val namespace = project.extensions.findByType(ApplicationExtension::class.java)?.namespace
+            boundaryCheck.configure { task -> task.applicationPackage.set(namespace.orEmpty()) }
+        }
+
+        target.tasks
+            .matching { task -> task.name == "preBuild" || task.name == "check" }
+            .configureEach { task -> task.dependsOn(boundaryCheck) }
+    }
+
+    private companion object {
+        /** Modules that survive every plug-out combination, so `:app` is allowed to name them. */
+        val PERMITTED_CORE_MODULES = listOf("common", "navigation", "ui")
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/AppModuleBoundaryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/AppModuleBoundaryPlugin.kt
@@ -3,6 +3,7 @@ package com.ytapps.composetemplate.convention
 import com.android.build.api.dsl.ApplicationExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 
 /**
  * Enforces plug-out criterion (2): the application module must never name a symbol that
@@ -19,31 +20,38 @@ import org.gradle.api.Project
  */
 class AppModuleBoundaryPlugin : Plugin<Project> {
     override fun apply(target: Project) {
+        // Registered with the two-argument overload on purpose. The three-argument form
+        // competes with register(String, Class, Object... constructorArgs), and Kotlin binds a
+        // trailing lambda to the vararg candidate, leaving the lambda parameter untyped.
         val boundaryCheck =
             target.tasks.register(
                 "checkAppModuleBoundary",
                 CheckAppModuleBoundaryTask::class.java,
-            ) { task ->
-                task.group = "verification"
-                task.description = "Fails when :app imports a symbol from a module that can be plugged out"
-                task.sources.from(target.layout.projectDirectory.dir("src"))
-                task.permittedCoreModules.set(PERMITTED_CORE_MODULES)
-                task.applicationPackage.convention("")
-                task.reportFile.set(
-                    target.layout.buildDirectory.file("reports/plugout/app-module-boundary.txt"),
-                )
-            }
+            )
+
+        boundaryCheck.configure { task: CheckAppModuleBoundaryTask ->
+            task.group = "verification"
+            task.description = "Fails when :app imports a symbol from a module that can be plugged out"
+            task.sources.from(target.layout.projectDirectory.dir("src"))
+            task.permittedCoreModules.set(PERMITTED_CORE_MODULES)
+            task.applicationPackage.convention("")
+            task.reportFile.set(
+                target.layout.buildDirectory.file("reports/plugout/app-module-boundary.txt"),
+            )
+        }
 
         // The namespace is assigned inside the module's own build script, which runs after
         // this plugin is applied, so it can only be read once evaluation has finished.
-        target.afterEvaluate { project ->
+        target.afterEvaluate { project: Project ->
             val namespace = project.extensions.findByType(ApplicationExtension::class.java)?.namespace
-            boundaryCheck.configure { task -> task.applicationPackage.set(namespace.orEmpty()) }
+            boundaryCheck.configure { task: CheckAppModuleBoundaryTask ->
+                task.applicationPackage.set(namespace.orEmpty())
+            }
         }
 
         target.tasks
-            .matching { task -> task.name == "preBuild" || task.name == "check" }
-            .configureEach { task -> task.dependsOn(boundaryCheck) }
+            .matching { task: Task -> task.name == "preBuild" || task.name == "check" }
+            .configureEach { task: Task -> task.dependsOn(boundaryCheck) }
     }
 
     private companion object {

--- a/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/CheckAppModuleBoundaryTask.kt
+++ b/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/CheckAppModuleBoundaryTask.kt
@@ -1,0 +1,134 @@
+package com.ytapps.composetemplate.convention
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Scans the application module's Kotlin sources and reports every import that reaches into a
+ * module which is allowed to be plugged out.
+ *
+ * Imports are matched textually on purpose. The check has to run before compilation, because
+ * after compilation the failure it prevents has already happened.
+ */
+abstract class CheckAppModuleBoundaryTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sources: ConfigurableFileCollection
+
+    /** Core module names, without the `core.` prefix, that `:app` may import from. */
+    @get:Input
+    abstract val permittedCoreModules: ListProperty<String>
+
+    /** The module's package root, used to tell project imports apart from third-party ones. */
+    @get:Input
+    abstract val applicationPackage: Property<String>
+
+    @get:OutputFile
+    abstract val reportFile: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val basePackage = applicationPackage.get()
+        if (basePackage.isBlank()) {
+            logger.warn("Skipping the app module boundary check: the application namespace is not set.")
+            writeReport("skipped: the application namespace could not be resolved")
+            return
+        }
+
+        val kotlinSources =
+            sources.asFileTree.files
+                .filter { file -> file.isFile && file.extension == "kt" }
+                .sortedBy { file -> file.invariantSeparatorsPath }
+
+        val violations = kotlinSources.flatMap { file -> violationsIn(file, basePackage) }
+
+        if (violations.isNotEmpty()) {
+            logger.error(buildFailureMessage(violations))
+            writeReport(violations.joinToString(separator = "\n"))
+            throw GradleException(
+                "The application module imports ${violations.size} symbol(s) from modules that must stay removable.",
+            )
+        }
+
+        writeReport("ok: ${kotlinSources.size} file(s) checked, no imports from optional modules")
+        logger.lifecycle("App module boundary check complete: ${kotlinSources.size} file(s) checked.")
+    }
+
+    private fun violationsIn(
+        file: File,
+        basePackage: String,
+    ): List<String> {
+        val projectPrefix = "$basePackage."
+        val permitted = permittedCoreModules.get().map { module -> "core.$module." }
+
+        return file.readLines().mapIndexedNotNull { index, rawLine ->
+            val imported = importedNameOrNull(rawLine) ?: return@mapIndexedNotNull null
+            if (!imported.startsWith(projectPrefix)) return@mapIndexedNotNull null
+
+            val relative = imported.removePrefix(projectPrefix)
+            val forbidden =
+                when {
+                    relative.startsWith(FEATURE_PREFIX) -> true
+                    relative.startsWith(CORE_PREFIX) -> permitted.none { allowed -> relative.startsWith(allowed) }
+                    else -> false
+                }
+
+            if (forbidden) "${file.name}:${index + 1}  import $imported" else null
+        }
+    }
+
+    private fun importedNameOrNull(rawLine: String): String? {
+        val line = rawLine.trim()
+        if (!line.startsWith(IMPORT_PREFIX)) return null
+        return line
+            .removePrefix(IMPORT_PREFIX)
+            .substringBefore(ALIAS_SEPARATOR)
+            .trim()
+            .takeUnless { candidate -> candidate.isEmpty() }
+    }
+
+    private fun buildFailureMessage(violations: List<String>): String {
+        val permitted = permittedCoreModules.get().joinToString(separator = ", ") { module -> "core.$module" }
+        return buildString {
+            appendLine()
+            appendLine("The application module imports symbols from modules that must stay removable:")
+            appendLine()
+            violations.forEach { violation -> appendLine("  $violation") }
+            appendLine()
+            appendLine("  :app may import these core modules only: $permitted - plus its own packages.")
+            appendLine()
+            appendLine("  Optional modules must reach the app through a multibinding, not an import:")
+            appendLine("    startup work      -> contribute an AppInitializer")
+            appendLine("    navigation events -> contribute a NavigationObserver")
+            appendLine("    a misplaced type  -> move it into core:common")
+            appendLine()
+            appendLine("  Removing an optional module has to stay a folder deletion. An import turns")
+            appendLine("  it into a compile error, which is exactly what this check prevents.")
+            appendLine()
+        }
+    }
+
+    private fun writeReport(summary: String) {
+        val report = reportFile.get().asFile
+        report.parentFile?.mkdirs()
+        report.writeText(summary + "\n")
+    }
+
+    private companion object {
+        const val IMPORT_PREFIX = "import "
+        const val ALIAS_SEPARATOR = " as "
+        const val CORE_PREFIX = "core."
+        const val FEATURE_PREFIX = "feature."
+    }
+}

--- a/wiki/06-quality-tests-ci.md
+++ b/wiki/06-quality-tests-ci.md
@@ -4,6 +4,18 @@
 
 Centralized in a static-analysis convention plugin: **ktlint** (plugin 14.2.0) and **detekt** 1.23.8, with `.editorconfig` at the root. Entry points: `./gradlew ktlintCheck detekt`.
 
+### Module boundary enforcement
+
+`composetemplate.app.boundary` is applied by the application convention plugin, so only application modules get it. It registers `checkAppModuleBoundary`, hooked into both `preBuild` and `check`, which parses every `import` under `app/src` and fails the build when the application module names a symbol from a module that is meant to be removable.
+
+The rule is an **allowlist, not a blocklist**: `:app` may import `core.common`, `core.navigation`, `core.ui` and its own packages. Anything else under `core.*` or `feature.*` is a violation. A module added later is therefore forbidden by default, and nobody has to remember to extend a list.
+
+Why a dedicated task instead of detekt's `ForbiddenImport`: the detekt configuration is a single root file shared by every module (`config.setFrom(files("$rootDir/config/detekt/detekt.yml"))`), so forbidding `core.analytics` imports globally would also flag `core:analytics`'s own sources. The boundary is a property of one module, so it is checked where it applies.
+
+The failure message names the file, the line, the offending import and the mechanism to use instead — an `AppInitializer` for startup work, a `NavigationObserver` for navigation events, or moving a misplaced type into `core:common`.
+
+Relationship to the CI `plug-out` job: the job proves that the modules it deletes are actually removable, after the fact and only for the modules listed in `ci.yml`. The Gradle task prevents the regression up front, for every module, on every build.
+
 ## Test stack
 
 Standardized by `composetemplate.test`: JUnit 4.13.2, MockK 1.14.11, Truth 1.4.5, `kotlinx-coroutines-test` 1.11.0, plus AndroidX JUnit/Espresso and Compose UI test artifacts declared in the catalog.
@@ -29,12 +41,13 @@ Standardized by `composetemplate.test`: JUnit 4.13.2, MockK 1.14.11, Truth 1.4.5
 
 ## CI: `.github/workflows/ci.yml`
 
-JDK 17 (temurin), `gradle/actions/setup-gradle@v4`, concurrency group with `cancel-in-progress`. Four jobs:
+JDK 17 (temurin), `gradle/actions/setup-gradle@v4`, concurrency group with `cancel-in-progress`. Five jobs:
 
 1. **lint** — `ktlintCheck` + `detekt`
 2. **test** — `testDebugUnitTest`
 3. **build** — `assembleDebug` + `:app:assembleRelease`
-4. **template-smoke** — the distinctive one:
+4. **plug-out** — deletes the optional modules listed in the job (`core/security`, `core/analytics`), strips their `include(...)` and `project(...)` lines, greps the Kotlin sources to prove nothing still references them, then runs `:app:assembleDebug`. The list grows with each plug-out refactor, which is what makes a regression unmergeable.
+5. **template-smoke** — the distinctive one:
    - `help --task scaffoldFeature`
    - `scaffoldFeature -PfeatureName=ci_feature`, then compile it
    - `scaffoldFeature -PfeatureName=ci_database_feature -PwithDatabase=true`, then compile `data` + `presentation`
@@ -45,18 +58,22 @@ The smoke job is the mechanism that keeps the generator honest: if a template fi
 
 ### CI weak points
 
-- Every job recreates `local.properties` and `secrets.properties` with an inline heredoc — the same block is duplicated **four times**, so any secret-key change must be applied in four places.
+- Every job recreates `local.properties` and `secrets.properties` with an inline heredoc — the same block is duplicated **five times**, so any secret-key change must be applied in five places.
 - No instrumentation tests, no benchmark run.
 - No report/coverage artifact upload; failures must be read from logs.
 - A sample signature hash is embedded in the workflow for release assembly.
+- The workflow file is YAML, so an invisible character on a blank line inside a `run: |` block makes GitHub skip the workflow entirely and report **zero** check runs rather than a failure. A PR that looks unchecked is the symptom.
 
 ## Local verification equivalent
 
 ```bash
 ./gradlew validateSecrets
+./gradlew checkAppModuleBoundary
 ./gradlew ktlintCheck detekt testDebugUnitTest assembleDebug :app:assembleRelease
 ./gradlew scanApkForSecrets hardeningReport
 ```
+
+`checkAppModuleBoundary` also runs as part of `preBuild`, so any `assemble*` task already covers it; the explicit invocation is for a fast boundary-only check.
 
 ---
 

--- a/wiki/07-risks-and-gaps.md
+++ b/wiki/07-risks-and-gaps.md
@@ -19,7 +19,7 @@ Findings from reading the code, ordered by practical impact. Each item is an obs
 | 6 | `safeCall` catches only `HttpException` and `IOException` | `BaseRepository` | Deserialization or `IllegalState` failures escape the `Result` abstraction and can crash callers that assume total coverage |
 | 7 | Theme state exposed through the navigation contract | `INavigationManager.isDarkModeFlow` | Misplaced responsibility; consumers depend on navigation to read appearance settings |
 | 8 | CI secret bootstrap duplicated five times | `.github/workflows/ci.yml` | Drift risk; a reusable workflow or composite action would collapse it into one definition |
-| 9 | No module-graph enforcement | build-logic | Layer rules live in tier plugins and review only; nothing fails the build when a boundary is crossed or a feature imports another feature |
+| 9 | Module-graph enforcement stops at `:app` | build-logic | `checkAppModuleBoundary` now fails the build when the application module imports a pluggable module, but every other edge is still guarded by review alone: a feature may import another feature, and a core module may import an optional one |
 | 10 | `SecretManager` is a global object requiring `initialize(context)` | `core:secrets` | Initialization-order coupling; a secret read before startup completes fails at runtime rather than compile time |
 
 ## Lower impact / by design but worth stating
@@ -94,7 +94,34 @@ The three fixes, one per shape of the problem:
 
 `MainActivity` now injects only `INavigationManager`, `ScreenRegistry`,
 `NetworkMonitor` and `Set<NavigationObserver>`, all from modules that are never
-deleted. The CI `plug-out` job is what keeps it that way.
+deleted.
+
+### The plug-out contract is a build rule, not a review convention
+
+Keeping `:app` clean by review does not survive contact with a growing template, so
+the rule is executable. `composetemplate.app.boundary` registers
+`checkAppModuleBoundary`, wired into `preBuild` and `check`, which reads every
+`import` under `app/src` and fails when the application module names a symbol from a
+pluggable module.
+
+Three properties were deliberate:
+
+- **Allowlist, not blocklist.** The check permits `core.common`, `core.navigation`,
+  `core.ui` and the app's own packages, and rejects everything else under `core.*`
+  or `feature.*`. A blocklist would need an edit every time a module is added, and
+  the edit that gets forgotten is exactly the one that matters.
+- **Anchored on the application namespace.** Imports are compared against the
+  module's own package root, read from the `namespace` in `afterEvaluate`. Matching a
+  bare `.core.` substring would flag `androidx.core.view.WindowCompat`.
+- **A Gradle task, not a detekt rule.** `config/detekt/detekt.yml` is one root file
+  shared by every module, so a global forbidden-import entry for `core.analytics`
+  would also fail `core:analytics`'s own sources. The boundary belongs to a single
+  module and is enforced there.
+
+This complements rather than replaces the CI `plug-out` job. The job proves that the
+modules it deletes are genuinely removable, after the fact and only for the modules
+listed in `ci.yml`; the task blocks the regression before it is committed, for every
+module.
 
 ### `core:network` is a transport layer, not a connectivity layer
 
@@ -126,7 +153,7 @@ analytics is a real, currently-optional consumer.
 4. Pick one serialization stack; add a broad `catch` to `safeCall` (5, 6).
 5. Move `isDarkModeFlow` to a theme/preferences contract (7).
 6. Extract the CI secret bootstrap into a composite action (8).
-7. Add a lint or detekt rule that fails the build when `:app` imports an optional module, so the plug-out contract is enforced at review time and not only by the CI delete job (9).
+7. Extend module-graph enforcement beyond the application module (9). `checkAppModuleBoundary` covers `:app`; still unenforced are feature → feature imports and core → optional edges. Both need a rule that can express per-module allowlists without a shared global configuration.
 
 ## Open questions for the maintainer
 


### PR DESCRIPTION
Closes remediation item 7 in `wiki/07`.

## Problem

Plug-out criterion (2) — *no other module imports an optional module's symbols* — had no enforcement. The CI `plug-out` job catches a violation only **after** the fact, and only for the two modules currently listed in `ci.yml`. Adding a fourth import to `MainActivity` would sail through review and quietly make a module undeletable again, exactly as `IAnalyticsManager`, `NetworkMonitor` and `LocaleManager` did before #20.

## Solution

A new convention plugin `composetemplate.app.boundary`, applied by `AndroidApplicationConventionPlugin` so only application modules get it. It registers `checkAppModuleBoundary` (group `verification`), wired into both `preBuild` and `check`, which parses every `import` under `app/src` and fails when the application module names a symbol from a pluggable module.

Three design points worth reviewing:

- **Allowlist, not blocklist.** `:app` may import `core.common`, `core.navigation`, `core.ui` and its own packages; everything else under `core.*` or `feature.*` is a violation. A module added later is forbidden by default, so there is no list to remember to update.
- **Anchored on the application namespace,** read from `ApplicationExtension.namespace` in `afterEvaluate`. Matching a bare `.core.` substring would have flagged `androidx.core.view.WindowCompat`.
- **A Gradle task, not detekt's `ForbiddenImport`.** `config/detekt/detekt.yml` is a single root file shared by every module, so forbidding `core.analytics` globally would also fail `core:analytics`'s own `di/AnalyticsModule.kt`.

The task is incremental: sources are `@InputFiles` with relative path sensitivity and a marker `@OutputFile`, so it goes up-to-date. If the namespace cannot be resolved it warns and skips rather than failing, which keeps generated projects buildable.

Failure output names the file, the line, the import, and the mechanism to use instead:

```
The application module imports symbols from modules that must stay removable:

  MainActivity.kt:14  import com.ytapps.composetemplate.core.analytics.IAnalyticsManager

  :app may import these core modules only: core.common, core.navigation, core.ui - plus its own packages.

  Optional modules must reach the app through a multibinding, not an import:
    startup work      -> contribute an AppInitializer
    navigation events -> contribute a NavigationObserver
    a misplaced type  -> move it into core:common
```

## Verified before writing the rule

- `:app` has exactly three Kotlin files (`App.kt`, `MainActivity.kt`, `ui/AppNavigation.kt`) and every project import in them is already core-only, so the strict form passes on `main` today.
- `benchmark/build.gradle.kts` applies `com.android.test`, not `composetemplate.android.application`, so the rule does not leak into `:benchmark` — which legitimately imports `feature.*` packages.

## Docs

`wiki/06` gains a *Module boundary enforcement* section, and two staleness bugs found while reading are fixed: it still claimed CI had **four** jobs (the `plug-out` job was missing) and that the secret bootstrap was duplicated **four** times (it is five). `wiki/07` updates item 9, marks remediation item 7 as delivered, and records the decision.

## Not in this PR

No workflow file is touched. Feature → feature and core → optional edges remain unenforced; that is now item 7 in the remediation order.