### PR TITLE
feat: discover modules from disk so plugging one out is a single folder delete

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,50 +80,16 @@ android {
 }
 
 dependencies {
-    implementation(project(":core:common"))
-    implementation(project(":core:secrets"))
-    implementation(project(":core:data"))
-    implementation(project(":core:network"))
-    implementation(project(":core:security"))
-    implementation(project(":core:ui"))
-    implementation(project(":core:navigation"))
-    implementation(project(":core:analytics"))
-    implementation(project(":core:config"))
-    implementation(project(":core:permission"))
-    implementation(project(":core:google-play"))
-    implementation(project(":core:database"))
-    implementation(project(":feature:auth:data"))
-    implementation(project(":feature:auth:domain"))
-    implementation(project(":feature:auth:navigation"))
-    implementation(project(":feature:auth:presentation"))
-    implementation(project(":feature:detail:data"))
-    implementation(project(":feature:detail:domain"))
-    implementation(project(":feature:detail:navigation"))
-    implementation(project(":feature:detail:presentation"))
-    implementation(project(":feature:home:data"))
-    implementation(project(":feature:home:domain"))
-    implementation(project(":feature:home:navigation"))
-    implementation(project(":feature:home:presentation"))
-    implementation(project(":feature:list:data"))
-    implementation(project(":feature:list:domain"))
-    implementation(project(":feature:list:navigation"))
-    implementation(project(":feature:list:presentation"))
-    implementation(project(":feature:onboarding:data"))
-    implementation(project(":feature:onboarding:domain"))
-    implementation(project(":feature:onboarding:navigation"))
-    implementation(project(":feature:onboarding:presentation"))
-    implementation(project(":feature:profile:data"))
-    implementation(project(":feature:profile:domain"))
-    implementation(project(":feature:profile:navigation"))
-    implementation(project(":feature:profile:presentation"))
-    implementation(project(":feature:search:data"))
-    implementation(project(":feature:search:domain"))
-    implementation(project(":feature:search:navigation"))
-    implementation(project(":feature:search:presentation"))
-    implementation(project(":feature:splash:data"))
-    implementation(project(":feature:splash:domain"))
-    implementation(project(":feature:splash:navigation"))
-    implementation(project(":feature:splash:presentation"))
+    // Every core and feature module found on disk is wired in automatically, so deleting a
+    // module's folder removes it from the build without an edit here, and scaffolding a new
+    // feature needs no edit either. Intermediate path projects such as :feature:auth own no
+    // build file and are skipped.
+    rootProject.subprojects
+        .filter { it.buildFile.isFile }
+        .map { it.path }
+        .filter { it.startsWith(":core:") || it.startsWith(":feature:") }
+        .sorted()
+        .forEach { implementation(project(it)) }
 
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/ScaffoldFeaturePlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/ScaffoldFeaturePlugin.kt
@@ -89,31 +89,9 @@ class ScaffoldFeaturePlugin : Plugin<Project> {
                     }
                 }
 
-                // Register in settings.gradle.kts
-                var settingsUpdated = false
-                val settingsFile = File(target.rootProject.rootDir, "settings.gradle.kts")
-                if (settingsFile.exists()) {
-                    val settingsContent = settingsFile.readText()
-                    val newIncludes = subModules.joinToString("\n") { "include(\":feature:$featureName:$it\")" }
-                    if (!settingsContent.contains(":feature:$featureName:")) {
-                        settingsFile.appendText("\n$newIncludes")
-                        settingsUpdated = true
-                    }
-                }
-
-                // Register in app/build.gradle.kts
-                var appDependenciesUpdated = false
-                val appBuildFile = File(target.rootProject.rootDir, "app/build.gradle.kts")
-                if (appBuildFile.exists()) {
-                    val appBuildContent = appBuildFile.readLines().toMutableList()
-                    val dependenciesIndex = appBuildContent.indexOfLast { it.trim().startsWith("implementation(project(\":feature:") }
-                    if (dependenciesIndex != -1) {
-                        val newDeps = subModules.map { "    implementation(project(\":feature:$featureName:$it\"))" }
-                        appBuildContent.addAll(dependenciesIndex + 1, newDeps)
-                        appBuildFile.writeText(appBuildContent.joinToString("\n"))
-                        appDependenciesUpdated = true
-                    }
-                }
+                // settings.gradle.kts and app/build.gradle.kts are intentionally left alone. Both
+                // derive their module list from the folders that exist on disk, so creating the
+                // directories above is already enough to register the feature with the build.
 
                 logger.lifecycle(
                     """
@@ -121,8 +99,8 @@ class ScaffoldFeaturePlugin : Plugin<Project> {
                     |✅ Feature '$featureName' scaffolded at feature/$featureName/
                     |
                     |Automation:
-                    |  - settings.gradle.kts: ${if (settingsUpdated) "updated" else "not changed"}
-                    |  - app/build.gradle.kts dependencies: ${if (appDependenciesUpdated) "updated" else "not changed"}
+                    |  - settings.gradle.kts: no edit needed, modules are discovered from disk
+                    |  - app/build.gradle.kts: no edit needed, :app wires every discovered module
                     |  - Room starter files: ${if (withDatabase) "created" else "skipped"}
                     |
                     |Next steps:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.File
+
 pluginManagement {
     includeBuild("build-logic")
     repositories {
@@ -18,50 +20,36 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "ComposeTemplate"
-include(":app")
-include(":core:common")
-include(":core:secrets")
-include(":core:data")
-include(":core:network")
-include(":core:security")
-include(":core:ui")
-include(":core:navigation")
-include(":core:analytics")
-include(":core:config")
-include(":core:permission")
-include(":core:google-play")
-include(":core:database")
-include(":feature:auth:data")
-include(":feature:auth:domain")
-include(":feature:auth:navigation")
-include(":feature:auth:presentation")
-include(":feature:detail:data")
-include(":feature:detail:domain")
-include(":feature:detail:navigation")
-include(":feature:detail:presentation")
-include(":feature:list:data")
-include(":feature:list:domain")
-include(":feature:list:navigation")
-include(":feature:list:presentation")
-include(":feature:profile:data")
-include(":feature:profile:domain")
-include(":feature:profile:navigation")
-include(":feature:profile:presentation")
-include(":feature:onboarding:data")
-include(":feature:onboarding:domain")
-include(":feature:onboarding:navigation")
-include(":feature:onboarding:presentation")
-include(":feature:search:data")
-include(":feature:search:domain")
-include(":feature:search:navigation")
-include(":feature:search:presentation")
-include(":feature:splash:data")
-include(":feature:splash:domain")
-include(":feature:splash:navigation")
-include(":feature:splash:presentation")
-include(":feature:home:data")
-include(":feature:home:domain")
-include(":feature:home:navigation")
-include(":feature:home:presentation")
-include(":benchmark")
-include(":baselineprofile")
+
+/*
+ * Modules are discovered from the filesystem instead of being listed one by one.
+ *
+ * The plug-out contract says a module must be removable by deleting its folder. That was never
+ * quite true while every module also had to be named here: deleting a folder left a dangling
+ * include() behind, and a dangling include() does not break one module, it breaks configuration
+ * for the entire build. Scanning removes that second step, and it removes the mirror-image step
+ * for scaffolding, which no longer has to patch this file to register a generated feature.
+ *
+ * A directory is a module when it directly contains a build.gradle.kts. Directories are still
+ * traversed after being included, because feature modules nest one level deeper than core ones.
+ */
+val nonModuleDirectories = setOf("build", "build-logic", "buildSrc", "gradle", "src")
+
+fun includeModulesUnder(
+    directory: File,
+    parentPath: String,
+) {
+    directory
+        .listFiles()
+        ?.filter { it.isDirectory && !it.name.startsWith(".") && it.name !in nonModuleDirectories }
+        ?.sortedBy { it.name }
+        ?.forEach { candidate ->
+            val modulePath = "$parentPath:${candidate.name}"
+            if (File(candidate, "build.gradle.kts").isFile) {
+                include(modulePath)
+            }
+            includeModulesUnder(candidate, modulePath)
+        }
+}
+
+includeModulesUnder(rootDir, "")

--- a/wiki/05-generator-and-scaffolding.md
+++ b/wiki/05-generator-and-scaffolding.md
@@ -33,12 +33,9 @@ Dependency wiring in the generated scripts: `data -> domain`, `presentation -> d
 
 ### Build-file automation
 
-1. **`settings.gradle.kts`** — appends four `include(":feature:<name>:<tier>")` lines, guarded by a `contains(":feature:<name>:")` check.
-2. **`app/build.gradle.kts`** — finds the **last** line starting with `implementation(project(":feature:` and inserts the four new dependencies after it.
+None, by design. `settings.gradle.kts` discovers modules by scanning for directories that directly contain a `build.gradle.kts`, and `:app` derives its `core` and `feature` dependencies from the discovered projects. Writing the folders above is therefore all it takes to register the feature with the build; the task logs `no edit needed` for both files and continues to next steps and the suggested verification command `./gradlew :feature:<name>:presentation:compileDebugKotlin`.
 
-The task then logs whether each file was actually updated, plus next steps and the suggested verification command `./gradlew :feature:<name>:presentation:compileDebugKotlin`.
-
-> **Warning:** Both edits are line/text based. If the anchor line in `app/build.gradle.kts` is absent or reformatted, the task reports `not changed` and continues successfully — leaving a generated feature that compiles standalone but is never included in the app. Always read the task output.
+This replaces an earlier mechanism worth knowing about, because its failure mode is a general lesson. The task used to append `include(":feature:<name>:<tier>")` lines to `settings.gradle.kts` and insert dependencies after the **last** line starting with `implementation(project(":feature:` in `app/build.gradle.kts`. The second edit was anchored on text: when the anchor was missing or reformatted, the task logged `not changed`, exited successfully, and left a feature that compiled on its own but was never part of the app. Deriving the list from the filesystem removes the anchor, and with it the failure.
 
 ## `create-new-app`
 
@@ -48,6 +45,7 @@ The task then logs whether each file was actually updated, plus next steps and t
 
 - Produces a **sibling** project directory (`../MyNewApp`).
 - Rebrands package name, application name, namespaces, manifests and resources across the tree.
+- Copies the tree and rewrites text; it never parses `settings.gradle.kts`, so module discovery applies unchanged to the generated project.
 - Native bindings survive the rename because JNI methods are bound dynamically via `RegisterNatives` with the class path injected from the Gradle namespace (see [04](04-secrets-and-hardening.md)).
 - CI asserts the generated project contains **no** `secrets.properties`, no `local.properties`, and no `.git` directory — i.e. no leaked credentials and no inherited history.
 

--- a/wiki/07-risks-and-gaps.md
+++ b/wiki/07-risks-and-gaps.md
@@ -6,33 +6,32 @@ Findings from reading the code, ordered by practical impact. Each item is an obs
 
 | # | Finding | Where | Why it matters |
 | --- | --- | --- | --- |
-| 1 | Scaffolding mutates build files by text anchor and fails silently | `ScaffoldFeaturePlugin` | If the last `implementation(project(":feature:` line in `app/build.gradle.kts` is missing or reformatted, the task logs `not changed` and still succeeds, producing a feature the app never includes |
-| 2 | Navigation back stack is not persisted | `NavigationManager` | A `@Singleton` in-memory `MutableStateFlow<List<INavigationItem>>` is lost on process death; users return to the start destination with no state restoration |
-| 3 | Unresolved routes render text instead of failing | `ScreenRegistry` | Fallback shows `"Screen not found: <route>"`; a DI wiring mistake ships as a broken screen rather than a build/test failure |
-| 4 | Test pyramid inverted | whole repo | 5 unit tests, all infrastructure; 8 presentation modules and the `BaseViewModel` contract are untested |
+| 1 | Navigation back stack is not persisted | `NavigationManager` | A `@Singleton` in-memory `MutableStateFlow<List<INavigationItem>>` is lost on process death; users return to the start destination with no state restoration |
+| 2 | Unresolved routes render text instead of failing | `ScreenRegistry` | Fallback shows `"Screen not found: <route>"`; a DI wiring mistake ships as a broken screen rather than a build/test failure |
+| 3 | Test pyramid inverted | whole repo | 5 unit tests, all infrastructure; 8 presentation modules and the `BaseViewModel` contract are untested |
 
 ## Medium impact
 
 | # | Finding | Where | Why it matters |
 | --- | --- | --- | --- |
-| 5 | Two serialization stacks | `NetworkModule` (Gson) vs `kotlin.serialization` for routes/models | Extra dependency surface, reflection, and ProGuard-keep burden for no functional gain |
-| 6 | `safeCall` catches only `HttpException` and `IOException` | `BaseRepository` | Deserialization or `IllegalState` failures escape the `Result` abstraction and can crash callers that assume total coverage |
-| 7 | Theme state exposed through the navigation contract | `INavigationManager.isDarkModeFlow` | Misplaced responsibility; consumers depend on navigation to read appearance settings |
-| 8 | CI secret bootstrap duplicated five times | `.github/workflows/ci.yml` | Drift risk; a reusable workflow or composite action would collapse it into one definition |
-| 9 | Module-graph enforcement stops at `:app` | build-logic | `checkAppModuleBoundary` now fails the build when the application module imports a pluggable module, but every other edge is still guarded by review alone: a feature may import another feature, and a core module may import an optional one |
-| 10 | `SecretManager` is a global object requiring `initialize(context)` | `core:secrets` | Initialization-order coupling; a secret read before startup completes fails at runtime rather than compile time |
+| 4 | Two serialization stacks | `NetworkModule` (Gson) vs `kotlin.serialization` for routes/models | Extra dependency surface, reflection, and ProGuard-keep burden for no functional gain |
+| 5 | `safeCall` catches only `HttpException` and `IOException` | `BaseRepository` | Deserialization or `IllegalState` failures escape the `Result` abstraction and can crash callers that assume total coverage |
+| 6 | Theme state exposed through the navigation contract | `INavigationManager.isDarkModeFlow` | Misplaced responsibility; consumers depend on navigation to read appearance settings |
+| 7 | CI secret bootstrap duplicated five times | `.github/workflows/ci.yml` | Drift risk; a reusable workflow or composite action would collapse it into one definition |
+| 8 | Module-graph enforcement stops at `:app` | build-logic | `checkAppModuleBoundary` now fails the build when the application module imports a pluggable module, but every other edge is still guarded by review alone: a feature may import another feature, and a core module may import an optional one |
+| 9 | `SecretManager` is a global object requiring `initialize(context)` | `core:secrets` | Initialization-order coupling; a secret read before startup completes fails at runtime rather than compile time |
 
 ## Lower impact / by design but worth stating
 
 | # | Finding | Note |
 | --- | --- | --- |
-| 11 | Bottom-bar order derives from multibinding key strings | Ordering is a naming convention, not a typed contract |
-| 12 | Fixed 4-module shape for every feature | Consistent, but trivial features (`splash`, `detail`) pay full configuration cost — 32 modules for 8 features |
-| 13 | Unbuffered event `Channel` in `BaseViewModel` | Single-consumer, rendezvous semantics; needs to be documented for feature authors |
-| 14 | `runBlocking` inside `TokenAuthenticator` | Required by OkHttp's blocking `Authenticator` API; rationale is in the source |
-| 15 | Certificate pinning disabled in debug | Pin misconfiguration only appears in release builds |
-| 16 | `config` module is local-only | `IConfigManager` + `LocalConfigProvider`; no remote-config backend, so runtime flags require a release |
-| 17 | Benchmarks and baseline profiles never run in CI | Performance infrastructure exists but is unmeasured |
+| 10 | Bottom-bar order derives from multibinding key strings | Ordering is a naming convention, not a typed contract |
+| 11 | Fixed 4-module shape for every feature | Consistent, but trivial features (`splash`, `detail`) pay full configuration cost — 32 modules for 8 features |
+| 12 | Unbuffered event `Channel` in `BaseViewModel` | Single-consumer, rendezvous semantics; needs to be documented for feature authors |
+| 13 | `runBlocking` inside `TokenAuthenticator` | Required by OkHttp's blocking `Authenticator` API; rationale is in the source |
+| 14 | Certificate pinning disabled in debug | Pin misconfiguration only appears in release builds |
+| 15 | `config` module is local-only | `IConfigManager` + `LocalConfigProvider`; no remote-config backend, so runtime flags require a release |
+| 16 | Benchmarks and baseline profiles never run in CI | Performance infrastructure exists but is unmeasured |
 
 ## Baseline decision log
 
@@ -76,6 +75,32 @@ and consumed as `Lazy<Set<T>>` where a dependency cycle has to stay broken (see
 `TokenAuthenticator`). One mechanism covers both "zero or one" and "zero or many",
 so the template teaches a single pattern rather than two.
 
+### Modules are discovered, not declared
+
+`settings.gradle.kts` scans the tree and includes every directory that directly
+contains a `build.gradle.kts`; `:app` builds its `core` and `feature` dependency
+list from the projects that scan produced. Neither file names a module.
+
+The reason is the plug-out contract's fourth criterion: deleting a module's folder
+must leave a working build. That was never actually true while the module was also
+named in two other files. A dangling `include()` does not break one module, it
+breaks configuration for the whole build, so "delete the folder" was really a
+three-file edit that CI had to reproduce with `sed`.
+
+The same change removes the mirror-image problem in `scaffoldFeature`, which used to
+patch both files after generating a feature — see [05](05-generator-and-scaffolding.md).
+
+Two details are load-bearing:
+
+- **`build-logic` must stay out of the scan.** It is an included build, not a
+  project; including it as one breaks the build. It sits in the skip list next to
+  `build`, `buildSrc`, `gradle` and `src`.
+- **Directories are traversed even after being included.** Core modules are one
+  level deep and feature modules are two, so recursion cannot stop at the first
+  match. Intermediate paths such as `feature/auth` own no build file, are never
+  included as projects, and are filtered out of `:app`'s dependency list by a
+  `buildFile.isFile` check.
+
 ### A module is only pluggable if `:app` never imports it
 
 Dependency injection is the easy half of the plug-out contract. The half that
@@ -109,10 +134,11 @@ Three properties were deliberate:
 - **Allowlist, not blocklist.** The check permits `core.common`, `core.navigation`,
   `core.ui` and the app's own packages, and rejects everything else under `core.*`
   or `feature.*`. A blocklist would need an edit every time a module is added, and
-  the edit that gets forgotten is exactly the one that matters.
+  the edit that gets forgotten is exactly the one that matters. This matters more now
+  that modules appear in the build merely by existing on disk.
 - **Anchored on the application namespace.** Imports are compared against the
-  module's own package root, read from the `namespace` in `afterEvaluate`. Matching a
-  bare `.core.` substring would flag `androidx.core.view.WindowCompat`.
+  module's own package root, read from the `namespace` through a lazy provider.
+  Matching a bare `.core.` substring would flag `androidx.core.view.WindowCompat`.
 - **A Gradle task, not a detekt rule.** `config/detekt/detekt.yml` is one root file
   shared by every module, so a global forbidden-import entry for `core.analytics`
   would also fail `core:analytics`'s own sources. The boundary belongs to a single
@@ -147,13 +173,12 @@ analytics is a real, currently-optional consumer.
 
 ## Suggested remediation order
 
-1. Make `scaffoldFeature` fail loudly when it cannot wire `settings.gradle.kts` or `app/build.gradle.kts` (item 1).
-2. Persist the navigation back stack and make unresolved routes fail in debug builds (2, 3).
-3. Add ViewModel tests for at least one full feature vertical and a `ScreenRegistry` coverage test (4, 3).
-4. Pick one serialization stack; add a broad `catch` to `safeCall` (5, 6).
-5. Move `isDarkModeFlow` to a theme/preferences contract (7).
-6. Extract the CI secret bootstrap into a composite action (8).
-7. Extend module-graph enforcement beyond the application module (9). `checkAppModuleBoundary` covers `:app`; still unenforced are feature → feature imports and core → optional edges. Both need a rule that can express per-module allowlists without a shared global configuration.
+1. Persist the navigation back stack and make unresolved routes fail in debug builds (1, 2).
+2. Add ViewModel tests for at least one full feature vertical and a `ScreenRegistry` coverage test (3, 2).
+3. Pick one serialization stack; add a broad `catch` to `safeCall` (4, 5).
+4. Move `isDarkModeFlow` to a theme/preferences contract (6).
+5. Extract the CI secret bootstrap into a composite action (7).
+6. Extend module-graph enforcement beyond the application module (8). `checkAppModuleBoundary` covers `:app`; still unenforced are feature → feature imports and core → optional edges. Both need a rule that can express per-module allowlists without a shared global configuration.
 
 ## Open questions for the maintainer
 


### PR DESCRIPTION
## Why

The plug-out contract's fourth criterion says a module must be removable by **deleting its folder**. That was not actually true: every module was also named in two other places, so deleting a folder left a dangling `include()` behind — and a dangling `include()` does not break one module, it breaks configuration for the entire build.

- `settings.gradle.kts` — 47 hand-maintained `include(...)` lines
- `app/build.gradle.kts` — 44 hand-maintained `implementation(project(...))` lines

CI papered over this with two `sed -i` lines in the `plug-out` job. That is the tell: the contract was only satisfiable by a script that edits source files.

## What changed

**`settings.gradle.kts`** now scans the tree and includes every directory that directly contains a `build.gradle.kts`. Recursion continues past a match because core modules are one level deep and feature modules are two. `build-logic` stays in the skip list — it is an *included build*, not a project.

**`app/build.gradle.kts`** derives its dependency list from the discovered projects:

```kotlin
rootProject.subprojects
    .filter { it.buildFile.isFile }
    .map { it.path }
    .filter { it.startsWith(":core:") || it.startsWith(":feature:") }
    .sorted()
    .forEach { implementation(project(it)) }
```

`buildFile.isFile` is what excludes the implicit intermediate projects (`:core`, `:feature`, `:feature:auth`) that Gradle creates for nested paths but that own no build script. `:benchmark`, `:baselineprofile` and `:app` itself fall outside the two prefixes and keep their explicit wiring.

**`ScaffoldFeaturePlugin`** stops patching both files. This also deletes the top high-impact finding in the wiki: the app-dependency insert was anchored on the *last* line starting with `implementation(project(":feature:`, and when that anchor was absent the task logged `not changed`, **exited successfully**, and left a feature that compiled standalone but was never part of the app. Discovery removes the anchor, so the failure mode cannot exist.

## Verification

- `create-new-app` is unaffected — it copies the tree and rewrites text, and never parses `settings.gradle.kts`. The `Template Smoke` job exercises both it and `scaffoldFeature`, including the generated feature's `compileDebugKotlin`, which is exactly the assertion that discovery replaced the settings patch correctly.
- The `plug-out` job's two `sed -i` lines now match nothing and exit 0, so **`ci.yml` is deliberately untouched** in this PR. They can be dropped as a follow-up.

## Docs

- `wiki/05` — build-file automation section rewritten; the old anchor mechanism is kept as a documented lesson rather than deleted silently.
- `wiki/07` — finding #1 retired and the remaining items renumbered, with a new decision-log entry *"Modules are discovered, not declared"* covering the `build-logic` exclusion and why recursion cannot stop at the first match.