### PR TITLE
feat: make baseline profile tooling pluggable via composetemplate.perf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,15 +153,17 @@ jobs:
 
       # Every module listed here must be deletable without touching any other source file.
       # The list grows with each plug-out refactor, which makes regressions impossible to merge.
+      #
+      # Deleting the folder is the whole operation: settings.gradle.kts discovers modules from
+      # disk, so there is nothing left to edit afterwards. The two sed calls that used to strip
+      # include() and project() lines were removed once that landed.
       - name: Delete optional modules
         run: |
           set -eu
-          for module in core/security core/analytics; do
+          for module in core/security core/analytics benchmark baselineprofile; do
             gradle_path=":$(echo "$module" | tr '/' ':')"
             echo "Removing $gradle_path"
             rm -rf "$module"
-            sed -i "\|include(\"$gradle_path\")|d" settings.gradle.kts
-            sed -i "\|project(\"$gradle_path\")|d" app/build.gradle.kts
           done
 
       - name: Verify no source references the removed modules
@@ -172,8 +174,19 @@ jobs:
             exit 1
           fi
 
+      # A successful build only proves the perf wiring did not explode; it does not prove the
+      # conditional branch ran. Asserting the log line proves composetemplate.perf actually took
+      # the "generator project is absent" path, so this job would still fail if the plugin
+      # silently started wiring baseline profiles unconditionally again.
       - name: Assemble debug without optional modules
-        run: ./gradlew :app:assembleDebug
+        run: |
+          set -euo pipefail
+          ./gradlew :app:assembleDebug | tee plug-out-build.log
+          if ! grep -q "Baseline profiles are disabled" plug-out-build.log; then
+            echo "composetemplate.perf did not report a missing :baselineprofile project."
+            echo "Either the plugin stopped being applied, or its wiring is no longer conditional."
+            exit 1
+          fi
 
   template-smoke:
     name: Template Smoke

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ import java.util.Properties
 plugins {
     id("composetemplate.create.new.app")
     id("composetemplate.android.application")
-    alias(libs.plugins.baselineprofile)
+    id("composetemplate.perf")
     id("composetemplate.android.application.compose")
     id("composetemplate.android.hilt")
     id("composetemplate.test")
@@ -63,6 +63,9 @@ android {
             )
         }
 
+        // Kept here deliberately. This build type references only app-local files, so it stays
+        // valid when the benchmark and baselineprofile modules are deleted; those modules select
+        // it through matchingFallbacks rather than the other way around.
         create("benchmark") {
             initWith(getByName("release"))
             matchingFallbacks += listOf("release")
@@ -103,7 +106,6 @@ dependencies {
     implementation(libs.androidx.material3.adaptive.navigation3)
     implementation(libs.kotlinx.serialization.core)
 
-    implementation(libs.androidx.profileinstaller)
-
-    baselineProfile(project(":baselineprofile"))
+    // Baseline profile wiring, including the profileinstaller runtime dependency, is contributed
+    // by composetemplate.perf and only when :baselineprofile exists.
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -87,5 +87,9 @@ gradlePlugin {
             id = "composetemplate.app.boundary"
             implementationClass = "com.ytapps.composetemplate.convention.AppModuleBoundaryPlugin"
         }
+        register("perf") {
+            id = "composetemplate.perf"
+            implementationClass = "com.ytapps.composetemplate.convention.PerfConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/PerfConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/ytapps/composetemplate/convention/PerfConventionPlugin.kt
@@ -1,0 +1,52 @@
+package com.ytapps.composetemplate.convention
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Wires baseline profile generation into the application module, but only when the generator
+ * project is part of the build.
+ *
+ * The conditional is the entire point. `:app` used to apply `androidx.baselineprofile` and
+ * declare `baselineProfile(project(":baselineprofile"))` plus the `profileinstaller` runtime
+ * dependency itself, which meant deleting `baselineprofile/` broke configuration of the
+ * application module. Performance tooling was therefore the last piece of the template that
+ * could not be plugged out, failing the contract's third criterion: a module's Gradle wiring
+ * must be self-contained.
+ *
+ * Since `settings.gradle.kts` discovers modules from the filesystem, "is the generator part of
+ * this build" and "does the folder exist" are now the same question, and
+ * [Project.findProject] answers it without any flag to keep in sync.
+ *
+ * The plugin id is applied rather than the typed extension being configured, so
+ * `androidx.baselineprofile` does not need to be on the convention project's compile
+ * classpath. It reaches the plugin classpath through `apply false` in the root build script,
+ * which is the same mechanism [AndroidHiltConventionPlugin] relies on for Hilt.
+ *
+ * Every lambda handed to Gradle elsewhere in this build is parameterless and uses its receiver,
+ * because Gradle's `Action<T>` surfaces in Kotlin as `T.() -> Unit`.
+ */
+class PerfConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        val generator = target.rootProject.findProject(GENERATOR_PROJECT_PATH)
+        if (generator == null) {
+            target.logger.lifecycle(
+                "Baseline profiles are disabled: $GENERATOR_PROJECT_PATH is not part of this build.",
+            )
+            return
+        }
+
+        target.pluginManager.apply(BASELINE_PROFILE_PLUGIN_ID)
+        target.dependencies.add(BASELINE_PROFILE_CONFIGURATION, generator)
+        target.dependencies.add(
+            "implementation",
+            target.libs.findLibrary("androidx-profileinstaller").get(),
+        )
+    }
+
+    private companion object {
+        const val GENERATOR_PROJECT_PATH = ":baselineprofile"
+        const val BASELINE_PROFILE_PLUGIN_ID = "androidx.baselineprofile"
+        const val BASELINE_PROFILE_CONFIGURATION = "baselineProfile"
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
     alias(libs.plugins.dagger.hilt) apply false
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.ktlint) apply false
+    // Resolved here but not applied, so that composetemplate.perf can apply it by id only when
+    // the generator project exists. Without this line the plugin would not be on the plugin
+    // classpath at all once :app stops declaring it.
+    alias(libs.plugins.baselineprofile) apply false
     id("composetemplate.validate.secrets")
     id("composetemplate.scaffold.feature")
 }

--- a/wiki/06-quality-tests-ci.md
+++ b/wiki/06-quality-tests-ci.md
@@ -16,6 +16,8 @@ The failure message names the file, the line, the offending import and the mecha
 
 Relationship to the CI `plug-out` job: the job proves that the modules it deletes are actually removable, after the fact and only for the modules listed in `ci.yml`. The Gradle task prevents the regression up front, for every module, on every build.
 
+What the task cannot see is a build-file coupling. It reads `import` lines, so a module named only in `app/build.gradle.kts` — which is exactly how the performance modules used to be wired — passes the check and still blocks deletion. That shape is caught by the `plug-out` job instead.
+
 ## Test stack
 
 Standardized by `composetemplate.test`: JUnit 4.13.2, MockK 1.14.11, Truth 1.4.5, `kotlinx-coroutines-test` 1.11.0, plus AndroidX JUnit/Espresso and Compose UI test artifacts declared in the catalog.
@@ -34,19 +36,20 @@ Standardized by `composetemplate.test`: JUnit 4.13.2, MockK 1.14.11, Truth 1.4.5
 
 ## Performance infrastructure
 
-- `:baselineprofile` module with the `androidx.baselineprofile` plugin, consumed by `app` via `baselineProfile(project(":baselineprofile"))`.
-- `:benchmark` module with Macrobenchmark + UI Automator.
-- Dedicated `benchmark` build type in `app` (`initWith(release)` + `benchmark-rules.pro`) and `androidx.profileinstaller` at runtime.
-- Neither benchmarks nor baseline-profile generation run in CI — the infrastructure exists, the measurement loop does not.
+- `:baselineprofile` module, configured by `composetemplate.baseline.profile.generator`.
+- `:benchmark` module with Macrobenchmark + UI Automator. It does **not** use that convention plugin: it applies `com.android.test` directly and repeats the same configuration by hand.
+- Dedicated `benchmark` build type in `app` (`initWith(release)` + `benchmark-rules.pro`). This one stays in the build file on purpose — it names no module, and the performance modules select it through `matchingFallbacks` rather than the reverse.
+- `composetemplate.perf` owns the rest of the wiring: applying `androidx.baselineprofile`, the `baselineProfile(project(":baselineprofile"))` dependency and `androidx.profileinstaller` at runtime. All three are contributed **only when `:baselineprofile` is present in the build**, so deleting the performance folders leaves a working application module. See the decision log in [07](07-risks-and-gaps.md#baseline-decision-log).
+- Neither benchmarks nor baseline-profile generation run in CI — the infrastructure exists, the measurement loop does not. What CI does verify is that the infrastructure is removable.
 
 ## CI: `.github/workflows/ci.yml`
 
 JDK 17 (temurin), `gradle/actions/setup-gradle@v4`, concurrency group with `cancel-in-progress`. Five jobs:
 
-1. **lint** — `ktlintCheck` + `detekt`
+1. **lint** — `ktlintCheck` + `detekt`. Also the job that compiles `build-logic`, so convention-plugin errors surface here first.
 2. **test** — `testDebugUnitTest`
 3. **build** — `assembleDebug` + `:app:assembleRelease`
-4. **plug-out** — deletes the optional modules listed in the job (`core/security`, `core/analytics`), strips their `include(...)` and `project(...)` lines, greps the Kotlin sources to prove nothing still references them, then runs `:app:assembleDebug`. The list grows with each plug-out refactor, which is what makes a regression unmergeable.
+4. **plug-out** — the contract's executable half. It deletes `core/security`, `core/analytics`, `benchmark` and `baselineprofile`, greps the Kotlin sources to prove nothing still references the two `core` modules, then runs `:app:assembleDebug`. The list grows with each plug-out refactor, which is what makes a regression unmergeable.
 5. **template-smoke** — the distinctive one:
    - `help --task scaffoldFeature`
    - `scaffoldFeature -PfeatureName=ci_feature`, then compile it
@@ -56,13 +59,30 @@ JDK 17 (temurin), `gradle/actions/setup-gradle@v4`, concurrency group with `canc
 
 The smoke job is the mechanism that keeps the generator honest: if a template file drifts and no longer compiles after generation, CI fails even though the template repository itself still builds.
 
+### Two details of the plug-out job worth knowing
+
+**Deleting the folder is the entire operation.** The job used to run two `sed` commands per module to strip `include(...)` from `settings.gradle.kts` and `project(...)` from `app/build.gradle.kts`. Once modules were discovered from disk those commands matched nothing, and they have been removed. If they are ever reintroduced, they are a sign that a module has been hardcoded somewhere again.
+
+**A green build is not sufficient proof.** `:app:assembleDebug` succeeding after the deletion only shows that nothing exploded; it does not show that `composetemplate.perf` took its conditional path. The job therefore asserts the plugin's log line:
+
+```bash
+./gradlew :app:assembleDebug | tee plug-out-build.log
+grep -q "Baseline profiles are disabled" plug-out-build.log
+```
+
+Without that assertion the job would still pass if the plugin silently stopped being applied, or started wiring baseline profiles unconditionally again. Note the `set -euo pipefail`: piping Gradle into `tee` would otherwise hide a Gradle failure behind `tee`'s exit code.
+
 ### CI weak points
 
-- Every job recreates `local.properties` and `secrets.properties` with an inline heredoc — the same block is duplicated **five times**, so any secret-key change must be applied in five places.
-- No instrumentation tests, no benchmark run.
+- Every job recreates `local.properties` and `secrets.properties` with an inline block — the same 14 lines are duplicated **five times**, so any secret-key change must be applied in five places.
+- No instrumentation tests. Benchmarks are proven removable but never actually run, so no performance number is ever measured.
 - No report/coverage artifact upload; failures must be read from logs.
 - A sample signature hash is embedded in the workflow for release assembly.
-- The workflow file is YAML, so an invisible character on a blank line inside a `run: |` block makes GitHub skip the workflow entirely and report **zero** check runs rather than a failure. A PR that looks unchecked is the symptom.
+- The workflow file is YAML, so an invisible character on a blank line inside a `run: |` block makes GitHub skip the workflow entirely and report **zero** check runs rather than a failure. A PR that looks unchecked is the symptom. To clear it:
+
+```bash
+perl -CSD -pi -e 's/\x{200b}//g' .github/workflows/ci.yml
+```
 
 ## Local verification equivalent
 

--- a/wiki/07-risks-and-gaps.md
+++ b/wiki/07-risks-and-gaps.md
@@ -31,7 +31,8 @@ Findings from reading the code, ordered by practical impact. Each item is an obs
 | 13 | `runBlocking` inside `TokenAuthenticator` | Required by OkHttp's blocking `Authenticator` API; rationale is in the source |
 | 14 | Certificate pinning disabled in debug | Pin misconfiguration only appears in release builds |
 | 15 | `config` module is local-only | `IConfigManager` + `LocalConfigProvider`; no remote-config backend, so runtime flags require a release |
-| 16 | Benchmarks and baseline profiles never run in CI | Performance infrastructure exists but is unmeasured |
+| 16 | Benchmarks and baseline profiles never run in CI | Performance infrastructure exists but is unmeasured. It is now at least removable — see the decision log below |
+| 17 | `benchmark/build.gradle.kts` bypasses its own convention plugin | It applies `com.android.test` directly and repeats every setting that `composetemplate.baseline.profile.generator` already applies for `:baselineprofile` |
 
 ## Baseline decision log
 
@@ -101,6 +102,48 @@ Two details are load-bearing:
   included as projects, and are filtered out of `:app`'s dependency list by a
   `buildFile.isFile` check.
 
+### Performance tooling is wired conditionally, not unconditionally
+
+Discovery made module folders deletable, but `:app` still reached out to the
+performance modules by name. Three lines in `app/build.gradle.kts` did it:
+`alias(libs.plugins.baselineprofile)`, `baselineProfile(project(":baselineprofile"))`
+and the `profileinstaller` runtime dependency. The first two fail configuration of
+the application module the moment `baselineprofile/` is deleted, which made the
+performance layer the last remaining violation of the contract's third criterion —
+a module's Gradle wiring must be self-contained.
+
+`composetemplate.perf` now owns all three. It calls
+`rootProject.findProject(":baselineprofile")` and does nothing but log when the
+result is `null`. Because modules are discovered from disk, that lookup and the
+question "does the folder still exist" are the same question, so there is no flag to
+keep in sync. `findProject` is used rather than `project(path)` specifically because
+the latter throws when the project is absent, which is the failure being removed.
+
+Two consequences worth knowing before touching this:
+
+- **The plugin is applied by id, and that requires a line in the root build script.**
+  `androidx.baselineprofile` reached the plugin classpath only through `:app`'s
+  `plugins {}` block, so removing that alias would have made
+  `pluginManager.apply("androidx.baselineprofile")` fail with "plugin not found". It
+  is now declared `apply false` at the root, the same mechanism
+  `AndroidHiltConventionPlugin` already relies on for Hilt. Applying by id also means
+  the convention project needs no `compileOnly` dependency, since no typed extension
+  is configured.
+- **The `benchmark` build type stays in `app/build.gradle.kts` on purpose.** It looks
+  like performance wiring, but it references only app-local files
+  (`benchmark-rules.pro` and the release signing config) and names no module. The
+  performance modules select it through `matchingFallbacks`, not the other way
+  around, so it remains valid after they are deleted. Moving it into the plugin would
+  mean calling `getDefaultProguardFile(...)` through
+  `com.android.build.api.dsl.ApplicationExtension`, which is not verified to expose
+  it; an unnecessary risk for no gain in removability.
+
+Still open: `benchmark/build.gradle.kts` does not use
+`composetemplate.baseline.profile.generator` at all (finding 17). Folding it in needs
+`targetSdk`, `testInstrumentationRunner`, the `androidx.benchmark.suppressErrors`
+argument and a build type added to that plugin, none of which are confirmed against
+`TestExtension` yet, so it was deliberately left out of this change.
+
 ### A module is only pluggable if `:app` never imports it
 
 Dependency injection is the easy half of the plug-out contract. The half that
@@ -149,6 +192,9 @@ modules it deletes are genuinely removable, after the fact and only for the modu
 listed in `ci.yml`; the task blocks the regression before it is committed, for every
 module.
 
+Note what the task does **not** catch: the performance wiring above was a build-file
+coupling, not an `import`. Boundary violations come in both shapes.
+
 ### `core:network` is a transport layer, not a connectivity layer
 
 `NetworkMonitor` was moved to `core:common` rather than solving the coupling by
@@ -179,6 +225,7 @@ analytics is a real, currently-optional consumer.
 4. Move `isDarkModeFlow` to a theme/preferences contract (6).
 5. Extract the CI secret bootstrap into a composite action (7).
 6. Extend module-graph enforcement beyond the application module (8). `checkAppModuleBoundary` covers `:app`; still unenforced are feature → feature imports and core → optional edges. Both need a rule that can express per-module allowlists without a shared global configuration.
+7. Fold `benchmark/build.gradle.kts` into `composetemplate.baseline.profile.generator` so the two performance modules stop configuring themselves differently (17).
 
 ## Open questions for the maintainer
 
@@ -186,6 +233,7 @@ analytics is a real, currently-optional consumer.
 - Should `ScreenRegistry` throw in debug builds and fall back only in release?
 - Is Gson kept deliberately (backend contract flexibility) or is it legacy?
 - Should `hardeningReport` and `scanApkForSecrets` be part of the CI release job rather than manual tasks?
+- Should the CI `plug-out` job also delete `benchmark/` and `baselineprofile/`, now that doing so is supposed to work?
 
 ---
 


### PR DESCRIPTION
## Problem

After #22 a module can be removed by deleting its folder — except for the performance layer. `:app` reached out to it by name in three places:

```kotlin
alias(libs.plugins.baselineprofile)                 // plugins block
baselineProfile(project(":baselineprofile"))        // dependencies
implementation(libs.androidx.profileinstaller)      // runtime half of the same feature
```

The first two fail configuration of the application module the moment `baselineprofile/` is deleted. That makes performance tooling the last violation of plug-out criterion **(3): a module's Gradle wiring must be self-contained**.

## Change

A nineteenth convention plugin, `composetemplate.perf`, owns all three lines and only contributes them when the generator project is actually in the build:

```kotlin
val generator = target.rootProject.findProject(":baselineprofile") ?: return // logs and does nothing
target.pluginManager.apply("androidx.baselineprofile")
target.dependencies.add("baselineProfile", generator)
target.dependencies.add("implementation", target.libs.findLibrary("androidx-profileinstaller").get())
```

`:app` keeps a single `id("composetemplate.perf")`. Since modules are discovered from disk, "is `:baselineprofile` in the build" and "does the folder exist" are the same question — there is no flag to keep in sync.

## Two decisions worth reviewing

**The root build script gains one line.** `androidx.baselineprofile` was on the plugin classpath *only* because `:app` declared it in `plugins {}`. Removing that alias without compensating would make `pluginManager.apply("androidx.baselineprofile")` fail with "plugin not found", so it is now `alias(libs.plugins.baselineprofile) apply false` at the root — the same mechanism `AndroidHiltConventionPlugin` already relies on for Hilt. Applying by id also means `build-logic` needs no new `compileOnly` dependency, since no typed extension is configured.

**The `benchmark` build type deliberately stays in `app/build.gradle.kts`.** It looks like performance wiring, but it names no module — it references only `benchmark-rules.pro` and the release signing config, both app-local. The performance modules select it via `matchingFallbacks`, not the reverse, so it stays valid after they are deleted. Moving it would require `getDefaultProguardFile(...)` on `com.android.build.api.dsl.ApplicationExtension`, which I have not verified exposes it — unnecessary risk for zero gain in removability. A comment in the build file records this.

## Deliberately out of scope

`benchmark/build.gradle.kts` does not use `composetemplate.baseline.profile.generator` at all: it applies `com.android.test` directly and hand-repeats every setting the plugin already applies for `:baselineprofile`. Folding it in needs `targetSdk`, `testInstrumentationRunner`, the `suppressErrors` argument and a build type added to that plugin, none of it confirmed against `TestExtension`. Logged as finding 17 and remediation step 7 in `wiki/07` rather than guessed at here.

## Verification to watch

The change is configuration-time only, so **Assemble** and **Plug-out** passing is the real signal — every job configures `:app`, which now goes through the new plugin.

What CI does **not** prove: it never deletes `baselineprofile/`, so the `findProject == null` branch stays untested. `wiki/07` asks whether the `plug-out` job should start deleting these two modules; that needs a workflow edit, which this connection cannot push.

## Files

| File | Change |
| --- | --- |
| `PerfConventionPlugin.kt` | new |
| `build-logic/convention/build.gradle.kts` | `register("perf")` |
| `build.gradle.kts` | `baselineprofile` declared `apply false` |
| `app/build.gradle.kts` | three lines out, one `id(...)` in |
| `wiki/07-risks-and-gaps.md` | decision-log entry, findings 16–17, remediation 7, one open question |
