### PR TITLE
docs: refresh module topology and setup docs after module discovery and perf plug-out

### DIFF
--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -14,12 +14,15 @@ build-logic/
 │       ├── AndroidLibraryConventionPlugin.kt
 │       ├── AndroidLibraryNativeConventionPlugin.kt # NDK secret management
 │       ├── AndroidRoomConventionPlugin.kt
+│       ├── AppModuleBoundaryPlugin.kt              # registers checkAppModuleBoundary
 │       ├── BaselineProfileGeneratorConventionPlugin.kt
+│       ├── CheckAppModuleBoundaryTask.kt
 │       ├── CreateNewAppPlugin.kt
 │       ├── FeatureDomainConventionPlugin.kt
 │       ├── FeatureDataConventionPlugin.kt
 │       ├── FeatureNavigationConventionPlugin.kt
 │       ├── FeaturePresentationConventionPlugin.kt
+│       ├── PerfConventionPlugin.kt                 # conditional baseline profile wiring
 │       ├── ScaffoldFeaturePlugin.kt
 │       ├── StaticAnalysisConventionPlugin.kt
 │       ├── TestConventionPlugin.kt
@@ -30,6 +33,9 @@ build-logic/
 
 ## ✨ Recent Improvements
 
+- **Module discovery**: `settings.gradle.kts` finds modules on disk, so adding or removing one needs no build-file edit.
+- **Enforced app boundary**: the build fails when `:app` imports a module that is meant to stay removable.
+- **Conditional performance tooling**: baseline profile wiring is applied only when the generator module exists.
 - **Compose Metrics & Reports**: Integrated support for generating performance and stability metrics.
 - **Secret Management**: Automated validation, native obfuscation, and artifact scanning support.
 - **Centralized Versioning**: Categorized dependencies in Version Catalog for better maintainability.
@@ -40,6 +46,7 @@ build-logic/
 **What it does:**
 - Applies the Android application plugin, Kotlin Android plugin, and shared SDK/default config.
 - Configures build types, packaging, and project-wide Android defaults.
+- Also applies `composetemplate.static.analysis` and `composetemplate.app.boundary`.
 
 ### `composetemplate.android.application.compose`
 **What it does:**
@@ -88,11 +95,24 @@ build-logic/
 - Applies Ktlint and Detekt consistently across modules.
 - Uses the shared Detekt config from `config/detekt/detekt.yml`.
 
+### `composetemplate.app.boundary`
+**What it does:**
+- Registers the `checkAppModuleBoundary` verification task and hooks it into the application module's build.
+- Fails the build when `:app` imports a symbol from any module other than `core:common`, `core:navigation` and `core:ui`.
+- Writes a report to `build/reports/plugout/app-module-boundary.txt`.
+- This is what keeps optional modules deletable: they must reach the app through DI multibindings rather than imports.
+
+### `composetemplate.perf`
+**What it does:**
+- Applies `androidx.baselineprofile`, adds the `:baselineprofile` generator dependency and the `profileinstaller` runtime dependency — but **only if the `:baselineprofile` project is part of the build**.
+- When the folder has been deleted, it logs that baseline profiles are disabled and does nothing else, so performance tooling can be plugged out with a folder delete.
+- CI asserts that log line, so a change that silently made the wiring unconditional again would fail instead of passing.
+
 ### `composetemplate.scaffold.feature`
 **What it does:**
 - Generates `data`, `domain`, `navigation`, and `presentation` feature sub-modules.
-- Wires settings/app dependencies.
 - Creates a route, ViewModel, UI state/event, stateless screen, screen provider, Hilt binding, and localized string resources.
+- Performs **no** build-file edits: module discovery registers the new folders, so the task logs `no edit needed` for `settings.gradle.kts` and `app/build.gradle.kts`.
 
 ### `composetemplate.create.new.app`
 **What it does:**

--- a/wiki/01-module-topology.md
+++ b/wiki/01-module-topology.md
@@ -8,37 +8,47 @@
 - `RepositoriesMode.FAIL_ON_PROJECT_REPOS` — all repositories centralized.
 - Foojay toolchain resolver `1.0.0` for JDK provisioning.
 - Root project name: `ComposeTemplate`.
+- Modules are **discovered from disk**. The script walks the tree and includes every directory that directly contains a `build.gradle.kts`, skipping `build`, `build-logic`, `buildSrc`, `gradle` and `src`. There is no hand-maintained `include(...)` list, which is why plugging a module out is a single folder delete.
 
 ## Module inventory
 
 | Group | Count | Notes |
 | --- | --- | --- |
 | `:app` | 1 | Composition root and dependency aggregator |
-| `:core:*` | 13 | analytics, common, config, data, database, google-play, navigation, network, permission, secrets, security, ui (+ related) |
+| `:core:*` | 12 | analytics, common, config, data, database, google-play, navigation, network, permission, secrets, security, ui |
 | `:feature:*:*` | 32 | 8 features x `domain`/`data`/`navigation`/`presentation` |
 | `:benchmark`, `:baselineprofile` | 2 | Macrobenchmark + Baseline Profile generation |
 
-## Convention plugins (17)
+These counts describe what the tree contains today, not a contract. Because modules are discovered, adding or deleting a module folder changes the inventory with no build-file edit anywhere.
+
+## Convention plugins (19)
 
 Applied by ID, e.g. `composetemplate.android.library`, `composetemplate.feature.presentation`.
 
-- **Android base**: `android.application`, `android.library`, `android.library.native`, `android.application.compose`, `android.hilt`, `android.room`
+- **Android base**: `android.application`, `android.application.compose`, `android.library`, `android.library.compose`, `android.library.native`, `android.hilt`, `android.room`
 - **Feature tiers**: `feature.domain`, `feature.data`, `feature.navigation`, `feature.presentation`
-- **Tooling**: `test`, `static.analysis`, `create.new.app`, `validate.secrets`, `baselineprofile.generator`, plus shared `ProjectExtensions`
+- **Tooling**: `test`, `static.analysis`, `create.new.app`, `scaffold.feature`, `validate.secrets`, `baseline.profile.generator`, `app.boundary`, `perf`, plus the shared `ProjectExtensions` helpers (not a plugin)
 
 Each feature tier plugin encodes what that layer is allowed to depend on — this is where Clean Architecture is actually implemented, rather than in package naming.
 
+Two of these exist to protect the plug-out property rather than to configure a module:
+
+- **`app.boundary`** registers `checkAppModuleBoundary`, which fails the build when `:app` imports a symbol from any module other than `core:common`, `core:navigation` or `core:ui`.
+- **`perf`** applies the baseline profile plugin and its dependencies **only when `:baselineprofile` is part of the build**, so deleting the folder is enough to remove performance tooling.
+
 ## `app/build.gradle.kts`
 
-- Plugins: `composetemplate.create.new.app`, `composetemplate.android.application`, `composetemplate.android.application.compose`, `composetemplate.android.hilt`, `composetemplate.test`, `androidx.baselineprofile`, `kotlin.serialization`.
+- Plugins: `composetemplate.create.new.app`, `composetemplate.android.application`, `composetemplate.perf`, `composetemplate.android.application.compose`, `composetemplate.android.hilt`, `composetemplate.test`, `kotlin.serialization`.
 - `namespace` and `applicationId` = `com.ytapps.composetemplate`; `versionCode`/`versionName` read from the version catalog.
 - **Release signing** values come from the `secrets` extension with a `local.properties` fallback.
 - `release`: `isMinifyEnabled = true`, `isShrinkResources = true`.
-- Extra `benchmark` build type: `initWith(release)` + `benchmark-rules.pro`.
+- Extra `benchmark` build type: `initWith(release)` + `benchmark-rules.pro`. It stays even though `:benchmark` itself is removable, because the build type is what a macrobenchmark run targets and keeping it costs nothing.
 - `buildConfig = true` (needed for secret and flag plumbing).
-- Declares **every** core and feature module dependency explicitly, plus Navigation3 libraries, Timber, and `profileinstaller`.
+- Core and feature module dependencies are **derived from the discovered projects**, not listed by hand. Only libraries `:app` uses directly are declared explicitly, such as the Navigation3 libraries and Timber.
 
-> **Warning:** Because `app/build.gradle.kts` lists all 32 feature modules by hand, it is mutated textually by `scaffoldFeature`. See [07 - Risks](07-risks-and-gaps.md).
+> **Note:** `:app` may import symbols only from `core:common`, `core:navigation` and `core:ui`. Every other module reaches the app through DI multibindings instead of imports, and `checkAppModuleBoundary` fails the build if that rule is broken. See [06 - Quality, Tests and CI](06-quality-tests-ci.md) and [07 - Risks](07-risks-and-gaps.md).
+
+One class of coupling this check cannot see is build-file coupling: `:app` once declared `baselineProfile(project(":baselineprofile"))` in its own script, which broke deletion of that module without a single Kotlin import. That is what `composetemplate.perf` fixed.
 
 ## Version catalog highlights
 

--- a/wiki/08-getting-started.md
+++ b/wiki/08-getting-started.md
@@ -71,6 +71,12 @@ Hard rules enforced by validation:
 ./gradlew scanApkForSecrets
 ```
 
+To reproduce the boundary rule that CI enforces on `:app`:
+
+```bash
+./gradlew :app:checkAppModuleBoundary
+```
+
 ## 5. Add your first feature
 
 ```bash
@@ -78,7 +84,10 @@ Hard rules enforced by validation:
 ./gradlew :feature:user_profile:presentation:compileDebugKotlin
 ```
 
-Read the task output: it reports whether `settings.gradle.kts` and `app/build.gradle.kts` were actually updated. If either says `not changed`, wire it manually before continuing.
+The task writes four sub-module folders and nothing else. It logs `no edit needed` for
+both `settings.gradle.kts` and `app/build.gradle.kts`, which is the expected output, not a
+warning: modules are discovered from disk, so creating the folders is what registers the
+feature with the build. Do not go looking for an `include(...)` line to add.
 
 After scaffolding you still need to:
 
@@ -86,13 +95,20 @@ After scaffolding you still need to:
 2. Register the route as a bottom-bar item if it belongs in the tab bar (multibinding key determines order).
 3. Add repository/use-case contracts if the feature needs data.
 
+## Removing what you do not need
+
+Optional modules are deleted, not disabled. Delete the folder and the build stops
+referencing it — no flags, no `include(...)` cleanup. CI proves this on every pull request
+by deleting `core/security`, `core/analytics`, `benchmark` and `baselineprofile` and
+building the app without them. See [06 - Quality, Tests and CI](06-quality-tests-ci.md).
+
 ## First-release checklist
 
 - [ ] `validateSecrets` passes with real values
 - [ ] Release keystore configured; `:app:assembleRelease` succeeds
 - [ ] `scanApkForSecrets` clean on the release artifact
 - [ ] `hardeningReport` reviewed; pinning decision made with a rotation plan
-- [ ] Real auth refresh endpoint implemented behind `ITokenRefresher`
+- [ ] An `ITokenRefresher` contributed if you need 401 retry — the template ships none, so today a 401 simply fails (see [03 - Network](03-network-and-auth.md))
 - [ ] `minSdk` reviewed against your own audience before the first release
 - [ ] Sample features (`detail`, design-system catalog) removed or adapted
 - [ ] CI secrets configured as environment variables


### PR DESCRIPTION
The last three refactors (module discovery, the app module boundary check, and conditional perf wiring) left documentation behind. None of this changes code; it removes statements that are now false.

## `wiki/01-module-topology.md`

Four claims stopped being true:

- *"Declares **every** core and feature module dependency explicitly, plus Navigation3 libraries, Timber, and `profileinstaller`"* — `:app` derives core and feature dependencies from the discovered projects, and `profileinstaller` moved into `composetemplate.perf`.
- The warning block stating that `app/build.gradle.kts` lists all 32 feature modules by hand and is *"mutated textually by `scaffoldFeature`"* — that mechanism was deliberately removed.
- **Convention plugins (17)** — there are 19, and the list was missing `android.library.compose`, `scaffold.feature`, `app.boundary` and `perf`. `baselineprofile.generator` was also written with the wrong id (`baseline.profile.generator`).
- `:app` was listed as applying `androidx.baselineprofile`; it applies `composetemplate.perf`.

Also: the `:core:*` count said 13 while the accompanying list named 12 modules, the discovery rule is now documented in the settings section, and the boundary rule is stated with a note that build-file coupling is a category `checkAppModuleBoundary` cannot detect — which is exactly how the baseline profile coupling survived unnoticed.

## `wiki/08-getting-started.md`

The scaffold section told the reader to check whether the task updated `settings.gradle.kts` and `app/build.gradle.kts`, and to *"wire it manually"* if either said `not changed`. That sends people looking for an edit that intentionally no longer happens. It now explains that `no edit needed` is the expected output.

The release checklist item *"Real auth refresh endpoint implemented behind `ITokenRefresher`"* implied the template ships one. It does not — the refresher is an optional multibinding contribution, and without it a 401 simply fails.

Added a short "Removing what you do not need" section and the `checkAppModuleBoundary` command, since neither the plug-out model nor the boundary task appeared anywhere in the getting-started path.

## `build-logic/README.md`

The file tree was missing `AppModuleBoundaryPlugin.kt`, `CheckAppModuleBoundaryTask.kt` and `PerfConventionPlugin.kt`, and there was no entry for `composetemplate.app.boundary` or `composetemplate.perf`. Both are documented now, along with the fact that `scaffold.feature` performs no build-file edits.

`wiki/05-generator-and-scaffolding.md` was checked and is already accurate; it is not touched.