### PR TITLE
docs: correct stale claims in project context and wiki index

### DIFF
--- a/wiki/00-project-context.md
+++ b/wiki/00-project-context.md
@@ -6,19 +6,19 @@ The mental model needed before reading any other page.
 
 The product is the **generator**, not the app. Evidence from `build-logic/convention`:
 
-| Plugin | Size | Role |
-| --- | --- | --- |
-| `ScaffoldFeaturePlugin.kt` | ~15.2 KB | Generates a 4-module feature and wires it into the build |
-| `ValidateSecretsPlugin.kt` | ~15.1 KB | `validateSecrets`, `scanApkForSecrets`, `hardeningReport` |
-| `CreateNewAppPlugin.kt` | ~8.5 KB | Rebrands the template into a new sibling project |
-| `AndroidLibraryNativeConventionPlugin.kt` | ~9.3 KB | NDK/CMake setup + secret injection |
+| Plugin | Role |
+| --- | --- |
+| `ScaffoldFeaturePlugin.kt` | Generates a four-module feature from templates |
+| `ValidateSecretsPlugin.kt` | `validateSecrets`, `scanApkForSecrets`, `hardeningReport` |
+| `CreateNewAppPlugin.kt` | Rebrands the template into a new sibling project |
+| `AndroidLibraryNativeConventionPlugin.kt` | NDK/CMake setup + secret injection |
 
-That is roughly 48 KB of build-time logic — more than most `core` modules contain of runtime logic. The application code under `app/` and `feature/` behaves as a **living fixture**: CI generates a feature and a whole new app from it on every push.
+Those four files carry more logic than most `core` modules contain of runtime logic. The application code under `app/` and `feature/` behaves as a **living fixture**: CI generates a feature and a whole new app from it on every push.
 
 ## Three layers to keep separate in your head
 
-1. **Generation layer** — `build-logic/convention`, Gradle tasks, text manipulation of `settings.gradle.kts` and `app/build.gradle.kts`.
-2. **Runtime infrastructure** — 13 `core:*` modules: navigation, network, secrets, security, data, database, ui, config, analytics, permission, google-play, common.
+1. **Generation layer** — `build-logic/convention` and its Gradle tasks. It writes new module folders. It does **not** edit `settings.gradle.kts` or `app/build.gradle.kts`, because both derive their contents from whichever module folders exist on disk.
+2. **Runtime infrastructure** — 12 `core:*` modules: analytics, common, config, data, database, google-play, navigation, network, permission, secrets, security, ui.
 3. **Product surface** — 8 features x 4 sub-modules, aggregated by `app`.
 
 ## Opinions the code enforces
@@ -28,17 +28,20 @@ That is roughly 48 KB of build-time logic — more than most `core` modules cont
 - Screen state is standardized by `BaseViewModel<S, E>`: one `StateFlow` for state, one `Channel` for one-shot events.
 - Secrets never live as plain Kotlin strings in release: they go through XOR-obfuscated byte arrays in native code.
 - Build conventions are not optional: modules apply `composetemplate.*` plugins instead of configuring Android/Kotlin/Hilt themselves.
+- Optional modules stay deletable: `:app` may import symbols only from `core:common`, `core:navigation` and `core:ui`, and `checkAppModuleBoundary` fails the build when that rule is broken. Everything else reaches the app through DI multibindings.
+- Modules are discovered from disk, so adding or removing one is a folder operation rather than a build-file edit.
 
 ## Opinions the code does *not* enforce (worth knowing)
 
-- There is no module-graph verification plugin. Layer boundaries are convention + review, not build-time assertion.
-- Feature-to-feature isolation is not checked; `app` depends on everything.
+- Feature-to-feature isolation is unchecked. The boundary task inspects `:app` only, so one feature importing another compiles happily.
+- The boundary task reads Kotlin `import` lines. Coupling expressed in a build file is invisible to it — `:app` once declared `baselineProfile(project(":baselineprofile"))`, which blocked deletion of that module without a single import.
+- `:app` still *depends* on every module at the Gradle level; what it may not do is *import* them. Removability comes from multibindings, not from a short dependency list.
 - Presentation modules have no tests, so the ViewModel/state contract is unverified by CI.
 
 ## Scale snapshot
 
-- ~48 Gradle modules (`:app`, 13 core, 32 feature, `:benchmark`, `:baselineprofile`).
-- Composite build: `pluginManagement { includeBuild("build-logic") }`.
+- 47 Gradle modules (`:app`, 12 core, 32 feature, `:benchmark`, `:baselineprofile`) — a count the discovery rule produces from the tree, not a fixed contract.
+- 19 convention plugins in a composite build: `pluginManagement { includeBuild("build-logic") }`.
 - `RepositoriesMode.FAIL_ON_PROJECT_REPOS` — modules cannot declare their own repositories.
 - Languages: Kotlin, C++, CMake.
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -7,12 +7,12 @@ This wiki is the **single documentation source** for ComposeTemplate. It is writ
 | # | Page | What it covers |
 | --- | --- | --- |
 | 00 | [Project Context](00-project-context.md) | What this repository really is, and the opinions it enforces |
-| 01 | [Module Topology and Build System](01-module-topology.md) | ~48 modules, 17 convention plugins, version catalog |
+| 01 | [Module Topology and Build System](01-module-topology.md) | 47 modules, 19 convention plugins, version catalog |
 | 02 | [Navigation and UI State](02-navigation-and-ui-state.md) | Hand-written back stack, `ScreenRegistry`, `BaseViewModel` |
 | 03 | [Network and Auth Token Flow](03-network-and-auth.md) | `safeCall`, `TokenAuthenticator`, certificate pinning |
 | 04 | [Secrets, Security and Hardening](04-secrets-and-hardening.md) | NDK/JNI secret pipeline and Gradle guardrails |
 | 05 | [Generator and Scaffolding Tooling](05-generator-and-scaffolding.md) | `scaffoldFeature`, `create-new-app` |
-| 06 | [Quality, Tests and CI](06-quality-tests-ci.md) | Unit tests, four CI jobs, template smoke test |
+| 06 | [Quality, Tests and CI](06-quality-tests-ci.md) | Unit tests, five CI jobs, template smoke test |
 | 07 | [Risks, Gaps and Open Questions](07-risks-and-gaps.md) | 17 findings, a remediation order and the baseline decision log |
 | 08 | [Getting Started](08-getting-started.md) | Commands and secret keys taken from the build |
 
@@ -26,11 +26,11 @@ Reading order: start with 00 for the mental model, then 01–06 for subsystems, 
 | Branch inspected | `main` |
 | Base package | `com.ytapps.composetemplate` |
 | License | Apache-2.0 |
-| Gradle modules | ~48 |
-| Convention plugins | 17 |
+| Gradle modules | 47 |
+| Convention plugins | 19 |
 | minSdk / targetSdk / compileSdk | 26 / 36 / 37 |
 | Kotlin / AGP / KSP | 2.0.21 / 9.2.1 / 2.0.21-1.0.28 |
 
 ## One-paragraph summary
 
-ComposeTemplate is not a sample app: it is a **Gradle-based project generator** whose own application code doubles as the live fixture that proves the generator works. The heaviest logic sits in `build-logic/convention` (feature scaffolding, app rebranding, secret validation), and the most opinionated runtime code sits in `core:navigation` (a hand-written back stack over Navigation3) and `core:secrets` (NDK/JNI secret obfuscation with dynamic `RegisterNatives`). The template's guardrails — secret validation, APK/AAB secret scanning, and a CI job that generates a feature and a whole new app and then compiles them — are its real differentiator.
+ComposeTemplate is not a sample app: it is a **Gradle-based project generator** whose own application code doubles as the live fixture that proves the generator works. The heaviest logic sits in `build-logic/convention` (feature scaffolding, app rebranding, secret validation), and the most opinionated runtime code sits in `core:navigation` (a hand-written back stack over Navigation3) and `core:secrets` (NDK/JNI secret obfuscation with dynamic `RegisterNatives`). The template's guardrails — secret validation, APK/AAB secret scanning, a build-time check that stops `:app` from importing any removable module, and CI jobs that generate a whole new app and delete four optional modules before rebuilding — are its real differentiator.


### PR DESCRIPTION
Docs-only. Fixes claims in `wiki/00-project-context.md` and `wiki/README.md` that no longer match `main`.

### `wiki/00-project-context.md`

| Was | Now | Why |
| --- | --- | --- |
| "There is no module-graph verification plugin. Layer boundaries are convention + review, not build-time assertion." | Replaced by an enforced-opinion bullet describing the `:app` import allowlist | `composetemplate.app.boundary` / `checkAppModuleBoundary` has enforced this at build time since #21. This was the most misleading line in the wiki. |
| `13 core:* modules` (twice) | `12` | The list on the same page already named 12 |
| Generation layer "text manipulation of `settings.gradle.kts` and `app/build.gradle.kts`" | Writes module folders; both build files derive from disk | That mechanism was removed in #22 |
| `ScaffoldFeaturePlugin` "generates a 4-module feature **and wires it into the build**" | Generates a four-module feature from templates | No build-file wiring happens any more |
| Plugin KB column + "roughly 48 KB of build-time logic" | Column dropped | Every figure was stale after the scaffold rewrite (`~15.2 KB` → 13.7 KB actual), and byte counts go stale on every edit without telling a reader anything actionable |
| "Feature-to-feature isolation is not checked; app depends on everything." | Split into three precise bullets | Feature↔feature really is unchecked, but the reasons matter: the task inspects `:app` only, it reads Kotlin imports so build-file coupling is invisible, and `:app` still *depends* on everything while being forbidden to *import* it |
| `~48 Gradle modules` | `47` | 1 `:app` + 12 core + 32 feature + `:benchmark` + `:baselineprofile`; the old figure came with the wrong core count |

Also adds the modules-discovered-from-disk opinion and the convention-plugin count to the scale snapshot.

### `wiki/README.md`

- `~48 modules, 17 convention plugins` → `47 modules, 19 convention plugins` (page 01 row and the source-of-truth table)
- `four CI jobs` → `five CI jobs` (page 06 row)
- Summary paragraph now names the two guardrails added since it was written: the build-time `:app` import check, and the CI job that deletes four optional modules before rebuilding

`07 | 17 findings` was checked and is correct, so it is untouched.

### Verification

Every number was re-derived from the tree at `e9123943`, not from memory: `core/` lists exactly 12 directories, `feature/` exactly 8, the convention package 20 files giving 19 registrations (`AndroidComposeConventionPlugin` serves two ids), and `ci.yml` defines 5 jobs. `wiki/02`, `wiki/03` and `wiki/04` were audited in the same pass and needed no changes.

No code paths touched, so CI runs should be cache hits and prove nothing beyond `mkdocs build --strict` on merge.