### PR TITLE
docs: describe the boundary check that actually ships

### DIFF
--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -11,17 +11,18 @@ build-logic/
 │       ├── AndroidApplicationConventionPlugin.kt
 │       ├── AndroidComposeConventionPlugin.kt
 │       ├── AndroidHiltConventionPlugin.kt
-│       ├── AndroidLibraryConventionPlugin.kt
+│       ├── AndroidLibraryConventionPlugin.kt       # applies static.analysis + module.boundary
 │       ├── AndroidLibraryNativeConventionPlugin.kt # NDK secret management
 │       ├── AndroidRoomConventionPlugin.kt
 │       ├── AppModuleBoundaryPlugin.kt              # registers checkAppModuleBoundary
 │       ├── BaselineProfileGeneratorConventionPlugin.kt
-│       ├── CheckAppModuleBoundaryTask.kt
+│       ├── CheckModuleBoundaryTask.kt              # the shared scanner, driven by task inputs
 │       ├── CreateNewAppPlugin.kt
 │       ├── FeatureDomainConventionPlugin.kt
 │       ├── FeatureDataConventionPlugin.kt
 │       ├── FeatureNavigationConventionPlugin.kt
 │       ├── FeaturePresentationConventionPlugin.kt
+│       ├── ModuleBoundaryPlugin.kt                 # registers checkModuleBoundary per module
 │       ├── PerfConventionPlugin.kt                 # conditional baseline profile wiring
 │       ├── ScaffoldFeaturePlugin.kt
 │       ├── StaticAnalysisConventionPlugin.kt
@@ -34,7 +35,7 @@ build-logic/
 ## ✨ Recent Improvements
 
 - **Module discovery**: `settings.gradle.kts` finds modules on disk, so adding or removing one needs no build-file edit.
-- **Enforced app boundary**: the build fails when `:app` imports a module that is meant to stay removable.
+- **Enforced module boundaries**: the build fails when any module imports another module it is not allowed to name — not just `:app`.
 - **Conditional performance tooling**: baseline profile wiring is applied only when the generator module exists.
 - **Compose Metrics & Reports**: Integrated support for generating performance and stability metrics.
 - **Secret Management**: Automated validation, native obfuscation, and artifact scanning support.
@@ -59,6 +60,7 @@ build-logic/
 **What it does:**
 - Applies the Android library plugin, Kotlin Android plugin, and shared library defaults.
 - Keeps module SDK and packaging configuration consistent.
+- Also applies `composetemplate.static.analysis` and `composetemplate.module.boundary`, which is how every library module gets a boundary check without opting in.
 
 ### `composetemplate.android.library.compose`
 **What it does:**
@@ -102,6 +104,24 @@ build-logic/
 - Writes a report to `build/reports/plugout/app-module-boundary.txt`.
 - This is what keeps optional modules deletable: they must reach the app through DI multibindings rather than imports.
 
+### `composetemplate.module.boundary`
+**What it does:**
+- Registers `checkModuleBoundary` for every Android library module, applied through `composetemplate.android.library` so no build script opts in.
+- Derives the rule from the module's own Gradle path:
+  - `core:common`, `core:navigation`, `core:ui` and `core:data` survive every plug-out combination, so they may name only each other. An import of an optional module from here would make that module undeletable everywhere.
+  - Any other `core:*` module may name any core module but never a feature.
+  - A `feature:X:*` module may name its own feature and any feature's `navigation` module — a feature's route contract is what it publishes — but not another feature's `domain`, `data` or `presentation` code.
+- Writes a report to `build/reports/plugout/module-boundary.txt`, and hooks into `preBuild` and `check`.
+- Narrow exceptions are declared per module, not in a shared file:
+
+```kotlin
+moduleBoundary {
+    additionalPermittedImports.add("feature.auth.domain.")
+}
+```
+
+- Both boundary plugins share one `CheckModuleBoundaryTask`. The task knows nothing about which module it is checking; guarded prefixes, permitted patterns and advice text all arrive as task inputs.
+
 ### `composetemplate.perf`
 **What it does:**
 - Applies `androidx.baselineprofile`, adds the `:baselineprofile` generator dependency and the `profileinstaller` runtime dependency — but **only if the `:baselineprofile` project is part of the build**.
@@ -143,7 +163,7 @@ All dependencies and versions are managed in `gradle/libs.versions.toml`.
 - **Kotlin**: 2.0.21
 
 The `minSdk` baseline is Android 8.0 (Oreo). It is read from the catalog by every
-convention plugin, so changing it there changes it for all ~48 modules at once.
+convention plugin, so changing it there changes it for all 47 modules at once.
 
 ## 🔧 Configuring Metrics
 

--- a/wiki/00-project-context.md
+++ b/wiki/00-project-context.md
@@ -28,20 +28,21 @@ Those four files carry more logic than most `core` modules contain of runtime lo
 - Screen state is standardized by `BaseViewModel<S, E>`: one `StateFlow` for state, one `Channel` for one-shot events.
 - Secrets never live as plain Kotlin strings in release: they go through XOR-obfuscated byte arrays in native code.
 - Build conventions are not optional: modules apply `composetemplate.*` plugins instead of configuring Android/Kotlin/Hilt themselves.
-- Optional modules stay deletable: `:app` may import symbols only from `core:common`, `core:navigation` and `core:ui`, and `checkAppModuleBoundary` fails the build when that rule is broken. Everything else reaches the app through DI multibindings.
+- Optional modules stay deletable, and this is enforced for **every** module rather than argued in review. `:app` may import symbols only from `core:common`, `core:navigation` and `core:ui`; the four core modules that survive every plug-out combination may name only each other; every other core module may not name a feature; and a feature may not name another feature except through its published navigation contract. `checkAppModuleBoundary` and `checkModuleBoundary` fail the build when that is broken. Everything else reaches its consumers through DI multibindings.
 - Modules are discovered from disk, so adding or removing one is a folder operation rather than a build-file edit.
 
 ## Opinions the code does *not* enforce (worth knowing)
 
-- Feature-to-feature isolation is unchecked. The boundary task inspects `:app` only, so one feature importing another compiles happily.
-- The boundary task reads Kotlin `import` lines. Coupling expressed in a build file is invisible to it — `:app` once declared `baselineProfile(project(":baselineprofile"))`, which blocked deletion of that module without a single import.
+- The boundary checks read Kotlin `import` lines. Coupling expressed in a build file is invisible to them — `:app` once declared `baselineProfile(project(":baselineprofile"))`, which blocked deletion of that module without a single import.
+- Removability is only *proven* for four modules. The CI plug-out job deletes `core/security`, `core/analytics`, `benchmark` and `baselineprofile`; the remaining optional modules satisfy the rule but are never actually deleted and rebuilt.
 - `:app` still *depends* on every module at the Gradle level; what it may not do is *import* them. Removability comes from multibindings, not from a short dependency list.
 - Presentation modules have no tests, so the ViewModel/state contract is unverified by CI.
+- `main` is unprotected: passing checks are not a merge requirement.
 
 ## Scale snapshot
 
 - 47 Gradle modules (`:app`, 12 core, 32 feature, `:benchmark`, `:baselineprofile`) — a count the discovery rule produces from the tree, not a fixed contract.
-- 19 convention plugins in a composite build: `pluginManagement { includeBuild("build-logic") }`.
+- 20 convention plugins in a composite build: `pluginManagement { includeBuild("build-logic") }`.
 - `RepositoriesMode.FAIL_ON_PROJECT_REPOS` — modules cannot declare their own repositories.
 - Languages: Kotlin, C++, CMake.
 

--- a/wiki/01-module-topology.md
+++ b/wiki/01-module-topology.md
@@ -21,19 +21,22 @@
 
 These counts describe what the tree contains today, not a contract. Because modules are discovered, adding or deleting a module folder changes the inventory with no build-file edit anywhere.
 
-## Convention plugins (19)
+Of these, 44 are Android library modules — every `core:*` and every `feature:*:*`, since even `feature:*:domain` applies `composetemplate.android.library`. That is the set the boundary check covers.
+
+## Convention plugins (20)
 
 Applied by ID, e.g. `composetemplate.android.library`, `composetemplate.feature.presentation`.
 
 - **Android base**: `android.application`, `android.application.compose`, `android.library`, `android.library.compose`, `android.library.native`, `android.hilt`, `android.room`
 - **Feature tiers**: `feature.domain`, `feature.data`, `feature.navigation`, `feature.presentation`
-- **Tooling**: `test`, `static.analysis`, `create.new.app`, `scaffold.feature`, `validate.secrets`, `baseline.profile.generator`, `app.boundary`, `perf`, plus the shared `ProjectExtensions` helpers (not a plugin)
+- **Tooling**: `test`, `static.analysis`, `create.new.app`, `scaffold.feature`, `validate.secrets`, `baseline.profile.generator`, `app.boundary`, `module.boundary`, `perf`, plus the shared `ProjectExtensions` helpers (not a plugin)
 
 Each feature tier plugin encodes what that layer is allowed to depend on — this is where Clean Architecture is actually implemented, rather than in package naming.
 
-Two of these exist to protect the plug-out property rather than to configure a module:
+Three of these exist to protect the plug-out property rather than to configure a module:
 
 - **`app.boundary`** registers `checkAppModuleBoundary`, which fails the build when `:app` imports a symbol from any module other than `core:common`, `core:navigation` or `core:ui`.
+- **`module.boundary`** registers `checkModuleBoundary` for every library module. It is applied by `composetemplate.android.library`, so no module opts in, and the rule it enforces is derived from the module's own Gradle path: the four core modules that survive every plug-out combination may name only each other, any other core module may not name a feature, and a feature may not name another feature except through its published `navigation` module.
 - **`perf`** applies the baseline profile plugin and its dependencies **only when `:baselineprofile` is part of the build**, so deleting the folder is enough to remove performance tooling.
 
 ## `app/build.gradle.kts`
@@ -46,9 +49,9 @@ Two of these exist to protect the plug-out property rather than to configure a m
 - `buildConfig = true` (needed for secret and flag plumbing).
 - Core and feature module dependencies are **derived from the discovered projects**, not listed by hand. Only libraries `:app` uses directly are declared explicitly, such as the Navigation3 libraries and Timber.
 
-> **Note:** `:app` may import symbols only from `core:common`, `core:navigation` and `core:ui`. Every other module reaches the app through DI multibindings instead of imports, and `checkAppModuleBoundary` fails the build if that rule is broken. See [06 - Quality, Tests and CI](06-quality-tests-ci.md) and [07 - Risks](07-risks-and-gaps.md).
+> **Note:** `:app` may import symbols only from `core:common`, `core:navigation` and `core:ui`, and every other module is held to its own version of the same rule by `checkModuleBoundary`. Modules reach each other through DI multibindings instead of imports, and the build fails when that is broken. See [06 - Quality, Tests and CI](06-quality-tests-ci.md) and [07 - Risks](07-risks-and-gaps.md#baseline-decision-log).
 
-One class of coupling this check cannot see is build-file coupling: `:app` once declared `baselineProfile(project(":baselineprofile"))` in its own script, which broke deletion of that module without a single Kotlin import. That is what `composetemplate.perf` fixed.
+One class of coupling these checks cannot see is build-file coupling: `:app` once declared `baselineProfile(project(":baselineprofile"))` in its own script, which broke deletion of that module without a single Kotlin import. That is what `composetemplate.perf` fixed, and it remains the open half of the rule.
 
 ## Version catalog highlights
 

--- a/wiki/07-risks-and-gaps.md
+++ b/wiki/07-risks-and-gaps.md
@@ -8,7 +8,7 @@ Findings from reading the code, ordered by practical impact. Each item is an obs
 | --- | --- | --- | --- |
 | 1 | Navigation back stack is not persisted | `NavigationManager` | A `@Singleton` in-memory `MutableStateFlow<List<INavigationItem>>` is lost on process death; users return to the start destination with no state restoration |
 | 2 | Unresolved routes render text instead of failing | `ScreenRegistry` | Fallback shows `"Screen not found: <route>"`; a DI wiring mistake ships as a broken screen rather than a build/test failure |
-| 3 | Test pyramid inverted | whole repo | 5 unit tests, all infrastructure; 8 presentation modules and the `BaseViewModel` contract are untested |
+| 3 | Test pyramid inverted | whole repo | The only unit tests are `BaseRepositoryTest` and `TokenAuthenticatorTest`, both `core:network` infrastructure; 8 presentation modules and the `BaseViewModel` contract are untested |
 
 ## Medium impact
 
@@ -18,7 +18,7 @@ Findings from reading the code, ordered by practical impact. Each item is an obs
 | 5 | `safeCall` catches only `HttpException` and `IOException` | `BaseRepository` | Deserialization or `IllegalState` failures escape the `Result` abstraction and can crash callers that assume total coverage |
 | 6 | Theme state exposed through the navigation contract | `INavigationManager.isDarkModeFlow` | Misplaced responsibility; consumers depend on navigation to read appearance settings |
 | 7 | CI secret bootstrap duplicated five times | `.github/workflows/ci.yml` | Drift risk; a reusable workflow or composite action would collapse it into one definition |
-| 8 | Module-graph enforcement stops at `:app` | build-logic | `checkAppModuleBoundary` now fails the build when the application module imports a pluggable module, but every other edge is still guarded by review alone: a feature may import another feature, and a core module may import an optional one |
+| 8 | Boundary enforcement sees imports, not build files | build-logic | Import-level enforcement now covers every module (see the decision log), but the check reads Kotlin `import` lines only. A `project(":…")` line in a build script couples two modules without an import — the exact shape that once blocked deleting `:baselineprofile` |
 | 9 | `SecretManager` is a global object requiring `initialize(context)` | `core:secrets` | Initialization-order coupling; a secret read before startup completes fails at runtime rather than compile time |
 
 ## Lower impact / by design but worth stating
@@ -26,13 +26,16 @@ Findings from reading the code, ordered by practical impact. Each item is an obs
 | # | Finding | Note |
 | --- | --- | --- |
 | 10 | Bottom-bar order derives from multibinding key strings | Ordering is a naming convention, not a typed contract |
-| 11 | Fixed 4-module shape for every feature | Consistent, but trivial features (`splash`, `detail`) pay full configuration cost — 32 modules for 8 features |
+| 11 | Fixed 4-module shape for every feature | Consistent, but trivial features (`splash`, `detail`) pay full configuration cost — 32 modules for 8 features. `feature/home/domain` currently contains only a `build.gradle.kts` and no sources at all |
 | 12 | Unbuffered event `Channel` in `BaseViewModel` | Single-consumer, rendezvous semantics; needs to be documented for feature authors |
 | 13 | `runBlocking` inside `TokenAuthenticator` | Required by OkHttp's blocking `Authenticator` API; rationale is in the source |
 | 14 | Certificate pinning disabled in debug | Pin misconfiguration only appears in release builds |
 | 15 | `config` module is local-only | `IConfigManager` + `LocalConfigProvider`; no remote-config backend, so runtime flags require a release |
-| 16 | Benchmarks and baseline profiles never run in CI | Performance infrastructure exists but is unmeasured. It is now at least removable — see the decision log below |
+| 16 | Benchmarks and baseline profiles never run in CI | Performance infrastructure exists but is unmeasured. CI proves the tooling is *removable*; it never proves a benchmark *runs*. See the decision log below |
 | 17 | `benchmark/build.gradle.kts` bypasses its own convention plugin | It applies `com.android.test` directly and repeats every setting that `composetemplate.baseline.profile.generator` already applies for `:baselineprofile` |
+| 18 | The CI plug-out job deletes 4 of roughly 12 optional modules | It removes `core/security`, `core/analytics`, `benchmark` and `baselineprofile`. `core:network`, `core:database`, `core:google-play`, `core:permission`, `core:config`, `core:secrets` and the 8 features are *argued* to be removable, not demonstrated. The boundary check closes the import half of that gap for every module, but no job actually deletes those folders and rebuilds |
+| 19 | `mkdocs build --strict` is not a pull-request check | The published site builds from `main` after merge, so a broken link or nav entry fails once it is already public rather than in review |
+| 20 | `main` is unprotected | Nothing requires the five checks to pass before merging, and a fast merge can outrun CI entirely: PR #25 was merged about a minute after it was opened, so none of its checks ever ran |
 
 ## Baseline decision log
 
@@ -189,11 +192,99 @@ Three properties were deliberate:
 
 This complements rather than replaces the CI `plug-out` job. The job proves that the
 modules it deletes are genuinely removable, after the fact and only for the modules
-listed in `ci.yml`; the task blocks the regression before it is committed, for every
-module.
+listed in `ci.yml`; the task blocks the regression before it is committed.
 
-Note what the task does **not** catch: the performance wiring above was a build-file
-coupling, not an `import`. Boundary violations come in both shapes.
+### The same rule now applies to every module, and it was proven by making it fail
+
+`checkAppModuleBoundary` guarded one module. Every other edge in the graph was still
+guarded by review alone, and two of those edges break the plug-out contract just as
+thoroughly:
+
+- a feature importing another feature's `data` or `presentation` code makes the two
+  features deletable only as a pair;
+- a core module that survives every plug-out combination importing an optional one
+  makes that optional module undeletable **everywhere**, because the importing module
+  is never the one being deleted.
+
+`composetemplate.module.boundary`, applied by `composetemplate.android.library`,
+registers `checkModuleBoundary` for all 44 library modules — every `core:*` and every
+`feature:*:*`, including `feature:*:domain`, which is an Android library rather than a
+JVM module. No build script opts in. The rule is derived from the module's own Gradle
+path, so a module added later is governed the moment its folder exists on disk, which
+is the same property that made module discovery worth doing.
+
+| Module | May not name | Permitted anyway |
+| --- | --- | --- |
+| `:app` | `core.*`, `feature.*` | `core.common`, `core.navigation`, `core.ui` |
+| `core:common`, `core:navigation`, `core:ui`, `core:data` | `core.*`, `feature.*` | those four, plus itself |
+| any other `core:*` | `feature.*` | any core module, never a feature |
+| `feature:X:*` | `feature.*` | `feature.X.*`, and any `feature.*.navigation.*` |
+
+**The navigation exception is design, not a loophole added to keep the build green.**
+`feature/auth/presentation` already declares `implementation(project(":feature:splash:navigation"))`
+to link to a route it does not own. A rule banning every cross-feature import would
+have declared that intended edge a violation on day one. So navigation is modelled as
+what a feature *publishes*: its route contract is public, its data and presentation
+code are private, and coupling to the latter is what actually stops two features from
+being removed independently. Permitted patterns therefore support `*` as a single
+package segment, which lets `feature.*.navigation.` be written once instead of once
+per feature.
+
+A module needing a narrow exception declares it in its own build script rather than in
+a shared file, for the same reason the check is a Gradle task and not a detekt rule:
+
+```kotlin
+moduleBoundary {
+    additionalPermittedImports.add("feature.auth.domain.")
+}
+```
+
+**How it was proven.** A green pipeline cannot establish that a check works, because a
+task that has quietly become inert produces exactly the same green. So the check was
+deliberately broken, once per rule branch, with probe commits that were then reverted:
+
+| Run | What it establishes |
+| --- | --- |
+| `33846040803` | Clean code, 5/5 green — the rules raise no false alarms on the graph as it stands |
+| `33847159068` | Control case: the task graph collapsed, `4 actionable tasks`, **no check ran at all** |
+| `33847887311` | Core rule rejects a violation: `:core:data:checkModuleBoundary FAILED`, `19 actionable tasks: 17 executed` |
+| `33848373441` | Feature rule rejects a violation: red only on the jobs that build `:app`, while Lint and Template Smoke stay green |
+| `33849020026` | After the revert, 5/5 green again on a tree identical to the pre-probe commit |
+
+The control case is the load-bearing row, and it is why the count of actionable tasks
+is quoted. The first probe pointed `core:data` at `core:network` — but `core:network`
+already depends on `core:data`, so the reverse edge closed a loop, Gradle rejected the
+task graph before running anything, and four red jobs proved nothing whatsoever. The
+outer signature was identical to a real violation. `4 actionable tasks` against
+`17 executed` is what separates "the check ran and rejected the import" from "the build
+died first".
+
+Two lessons worth keeping for the next probe:
+
+- **Adding a reverse edge into an always-present core module tends to create a cycle,**
+  because the optional modules already depend on the always-present ones. Read the
+  target module's `build.gradle.kts` before authoring the violation. The retargeted
+  probe used `core:config`, which depends only on `:core:common`.
+- **Enumerate the failure modes that precede the mechanism under test,** not only the
+  ones that follow it. The probe was built so the boundary check was the only thing
+  that *could* fail — the violating import resolved to a real public symbol, the
+  project dependency was declared, and the import was used, so neither an unresolved
+  reference nor a ktlint unused-import could be mistaken for the rule firing.
+  `checkModuleBoundary` runs from `preBuild`, before `compileKotlin`, which is also
+  why `ktlintCheck` stays green during a violation: it never triggers `preBuild`.
+
+One implementation detail is easy to "tidy" back into a bug. The failure report travels
+in the `GradleException` message rather than through `logger.error`. Gradle flushes
+console output line by line and attributes each line to whichever task is current, so
+under parallel execution a multi-line error came apart — the header printed beneath a
+different module's task, with the offending import far below it. For a check whose
+whole purpose is to name the module that broke the rule, a report separable from its own
+module name is a defect. An exception message is printed under `* What went wrong:` as
+one block, already prefixed with the failing task path.
+
+What this still does not catch is build-file coupling (finding 8): the performance
+wiring was a `project(":baselineprofile")` line, not an `import`. Boundary violations
+come in both shapes, and only one of them is enforced today.
 
 ### `core:network` is a transport layer, not a connectivity layer
 
@@ -209,6 +300,11 @@ making `core:network` a Compose module or by letting `core:ui` depend on
 The move costs nothing: `NetworkMonitor` imports only `android.net.*` and
 `@ApplicationContext`, and `core:common` already applies the Hilt convention plugin.
 
+Worth knowing when reading the graph: `core:network` itself depends on `core:data`.
+That is the permitted direction — optional depending on always-present — but it shows
+how central `core:data` is, which is why `core:data` is one of the four modules held to
+the strictest rule above.
+
 ### Extension points are added when there is a second user, not before
 
 An injectable "app chrome" slot was considered so that optional modules could
@@ -221,19 +317,19 @@ analytics is a real, currently-optional consumer.
 
 1. Persist the navigation back stack and make unresolved routes fail in debug builds (1, 2).
 2. Add ViewModel tests for at least one full feature vertical and a `ScreenRegistry` coverage test (3, 2).
-3. Pick one serialization stack; add a broad `catch` to `safeCall` (4, 5).
+3. Pick one serialization stack; add a broad `catch` to `safeCall` (4, 5). A broad catch must rethrow `CancellationException` before mapping anything else, or a cancelled coroutine is silently converted into a failed `Result` and the caller treats teardown as an error.
 4. Move `isDarkModeFlow` to a theme/preferences contract (6).
 5. Extract the CI secret bootstrap into a composite action (7).
-6. Extend module-graph enforcement beyond the application module (8). `checkAppModuleBoundary` covers `:app`; still unenforced are feature → feature imports and core → optional edges. Both need a rule that can express per-module allowlists without a shared global configuration.
+6. Extend boundary enforcement to build files (8). The import half shipped: `checkModuleBoundary` covers every module, with per-module rules and a per-module escape hatch. The remaining half is a check that scans module `build.gradle.kts` files for `project(":…")` edges against the same allowlists — an import scanner cannot see that shape by construction. Such a check has to reason about dependency direction rather than pattern-match, since a reverse edge into an always-present module is also how a task-graph cycle gets created.
 7. Fold `benchmark/build.gradle.kts` into `composetemplate.baseline.profile.generator` so the two performance modules stop configuring themselves differently (17).
+8. Give the plug-out job broader coverage, or state its limits in the README (18). Four modules are proven removable; the rest are argued.
 
 ## Open questions for the maintainer
 
-- Is the fixed 4-module feature shape intended to be non-negotiable, or should `scaffoldFeature` support a lighter UI-only variant?
+- Is the fixed 4-module feature shape intended to be non-negotiable, or should `scaffoldFeature` support a lighter UI-only variant? (`feature/home/domain` is currently an empty module, which is the same question asked by the tree.)
 - Should `ScreenRegistry` throw in debug builds and fall back only in release?
 - Is Gson kept deliberately (backend contract flexibility) or is it legacy?
 - Should `hardeningReport` and `scanApkForSecrets` be part of the CI release job rather than manual tasks?
-- Should the CI `plug-out` job also delete `benchmark/` and `baselineprofile/`, now that doing so is supposed to work?
 
 ---
 

--- a/wiki/08-getting-started.md
+++ b/wiki/08-getting-started.md
@@ -71,11 +71,19 @@ Hard rules enforced by validation:
 ./gradlew scanApkForSecrets
 ```
 
-To reproduce the boundary rule that CI enforces on `:app`:
+To reproduce the boundary rules that CI enforces, run any of the checks on their own:
 
 ```bash
 ./gradlew :app:checkAppModuleBoundary
+./gradlew :core:data:checkModuleBoundary
+./gradlew :feature:auth:presentation:checkModuleBoundary
 ```
+
+Each task is wired into both `preBuild` and `check`, so an ordinary `assembleDebug` or
+`testDebugUnitTest` already runs them for every module. Note that `ktlintCheck` does
+**not** trigger `preBuild`, so a lint-only run will not surface a boundary violation.
+What a failure looks like, and why it is worded the way it is, is in
+[07 - Risks](07-risks-and-gaps.md#baseline-decision-log).
 
 ## 5. Add your first feature
 
@@ -89,6 +97,9 @@ both `settings.gradle.kts` and `app/build.gradle.kts`, which is the expected out
 warning: modules are discovered from disk, so creating the folders is what registers the
 feature with the build. Do not go looking for an `include(...)` line to add.
 
+The new feature is governed by `checkModuleBoundary` from its first build, because the
+rule comes from the module's Gradle path rather than from a list someone has to update.
+
 After scaffolding you still need to:
 
 1. Replace the generated placeholder UI/state with the real screen.
@@ -98,9 +109,22 @@ After scaffolding you still need to:
 ## Removing what you do not need
 
 Optional modules are deleted, not disabled. Delete the folder and the build stops
-referencing it — no flags, no `include(...)` cleanup. CI proves this on every pull request
-by deleting `core/security`, `core/analytics`, `benchmark` and `baselineprofile` and
-building the app without them. See [06 - Quality, Tests and CI](06-quality-tests-ci.md).
+referencing it — no flags, no `include(...)` cleanup. Two mechanisms keep that true: the
+boundary checks fail the build when a module imports something it is not allowed to name,
+so the coupling never accumulates in the first place; and CI proves the result on every
+pull request by deleting `core/security`, `core/analytics`, `benchmark` and
+`baselineprofile` and building the app without them.
+
+If you need a genuine exception, declare it in the importing module's own build script
+rather than weakening the rule for everyone:
+
+```kotlin
+moduleBoundary {
+    additionalPermittedImports.add("feature.auth.domain.")
+}
+```
+
+See [06 - Quality, Tests and CI](06-quality-tests-ci.md).
 
 ## First-release checklist
 

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -7,13 +7,13 @@ This wiki is the **single documentation source** for ComposeTemplate. It is writ
 | # | Page | What it covers |
 | --- | --- | --- |
 | 00 | [Project Context](00-project-context.md) | What this repository really is, and the opinions it enforces |
-| 01 | [Module Topology and Build System](01-module-topology.md) | 47 modules, 19 convention plugins, version catalog |
+| 01 | [Module Topology and Build System](01-module-topology.md) | 47 modules, 20 convention plugins, version catalog |
 | 02 | [Navigation and UI State](02-navigation-and-ui-state.md) | Hand-written back stack, `ScreenRegistry`, `BaseViewModel` |
 | 03 | [Network and Auth Token Flow](03-network-and-auth.md) | `safeCall`, `TokenAuthenticator`, certificate pinning |
 | 04 | [Secrets, Security and Hardening](04-secrets-and-hardening.md) | NDK/JNI secret pipeline and Gradle guardrails |
 | 05 | [Generator and Scaffolding Tooling](05-generator-and-scaffolding.md) | `scaffoldFeature`, `create-new-app` |
 | 06 | [Quality, Tests and CI](06-quality-tests-ci.md) | Unit tests, five CI jobs, template smoke test |
-| 07 | [Risks, Gaps and Open Questions](07-risks-and-gaps.md) | 17 findings, a remediation order and the baseline decision log |
+| 07 | [Risks, Gaps and Open Questions](07-risks-and-gaps.md) | 20 findings, a remediation order and the baseline decision log |
 | 08 | [Getting Started](08-getting-started.md) | Commands and secret keys taken from the build |
 
 Reading order: start with 00 for the mental model, then 01–06 for subsystems, and read 07 before making changes.
@@ -27,10 +27,10 @@ Reading order: start with 00 for the mental model, then 01–06 for subsystems, 
 | Base package | `com.ytapps.composetemplate` |
 | License | Apache-2.0 |
 | Gradle modules | 47 |
-| Convention plugins | 19 |
+| Convention plugins | 20 |
 | minSdk / targetSdk / compileSdk | 26 / 36 / 37 |
 | Kotlin / AGP / KSP | 2.0.21 / 9.2.1 / 2.0.21-1.0.28 |
 
 ## One-paragraph summary
 
-ComposeTemplate is not a sample app: it is a **Gradle-based project generator** whose own application code doubles as the live fixture that proves the generator works. The heaviest logic sits in `build-logic/convention` (feature scaffolding, app rebranding, secret validation), and the most opinionated runtime code sits in `core:navigation` (a hand-written back stack over Navigation3) and `core:secrets` (NDK/JNI secret obfuscation with dynamic `RegisterNatives`). The template's guardrails — secret validation, APK/AAB secret scanning, a build-time check that stops `:app` from importing any removable module, and CI jobs that generate a whole new app and delete four optional modules before rebuilding — are its real differentiator.
+ComposeTemplate is not a sample app: it is a **Gradle-based project generator** whose own application code doubles as the live fixture that proves the generator works. The heaviest logic sits in `build-logic/convention` (feature scaffolding, app rebranding, secret validation), and the most opinionated runtime code sits in `core:navigation` (a hand-written back stack over Navigation3) and `core:secrets` (NDK/JNI secret obfuscation with dynamic `RegisterNatives`). The template's guardrails — secret validation, APK/AAB secret scanning, a build-time check that stops any module from importing a module it is not allowed to name, and CI jobs that generate a whole new app and delete four optional modules before rebuilding — are its real differentiator.


### PR DESCRIPTION
The follow-up deliberately left out of #26. That PR generalized module-boundary enforcement from `:app` to every library module; six documents still described the narrower check. Docs written against proven behaviour rather than intended behaviour, which is the whole reason they were held back.

No code changes. Six files.

## `wiki/07`

**Finding 8 was the stale one.** It read "Module-graph enforcement stops at `:app`". That gap is closed, so instead of deleting the row it now states the gap that *remains*: the check reads Kotlin `import` lines, so a `project(":…")` line in a build script still couples two modules invisibly to it. The finding keeps its number and its impact tier, because the risk did not disappear — it got smaller and more specific.

**Remediation 6** records which half shipped and which did not, and adds a constraint discovered the hard way: a build-file check has to reason about dependency *direction*, not just pattern-match, because a reverse edge into an always-present module is also how a Gradle task-graph cycle gets created.

**A new decision-log entry** carries the rule table, why the `feature.*.navigation.*` exception is existing design rather than a loophole added to keep the build green, the per-module escape hatch, and how the check was proven by deliberately breaking it — including the control case, the two probe lessons, and why the failure report travels in the exception message instead of `logger.error`.

**Remediation 3** gains the `CancellationException` note. A broad `catch` in `safeCall` must rethrow it before mapping anything else, or a cancelled coroutine is silently converted into a failed `Result` and the caller treats teardown as an error. Adding a broad catch without that line makes the code worse, not better.

**Three risks added** (18–20) that were true for a while but unstated:

- the CI plug-out job deletes 4 of roughly 12 optional modules; the rest satisfy the rule but are never actually deleted and rebuilt, so they are argued rather than demonstrated;
- `mkdocs build --strict` is not a pull-request check, so a broken link fails after merge, once it is already public;
- `main` is unprotected, and a fast merge can outrun CI entirely — #25 was merged about a minute after opening and none of its checks ran.

**Two corrections rather than additions:**

- Finding 3 no longer claims "5 unit tests". That number was never re-derived from the tree, and I am not going to restate a figure I cannot defend. It now names the two test classes that demonstrably exist, `BaseRepositoryTest` and `TokenAuthenticatorTest`, which is the part that supports the finding anyway.
- The fifth open question — should the plug-out job also delete `benchmark/` and `baselineprofile/` — is removed. #23 did exactly that; the question had been answered by the CI file for several PRs while still being asked on the page.

Finding 11 picks up the empty-module observation (`feature/home/domain` has a `build.gradle.kts` and no sources), since it is the same question the row already asks. Finding 16 now separates what CI proves — the performance tooling is *removable* — from what it does not: that a benchmark ever *runs*.

## `wiki/00`, `wiki/01`, `wiki/README.md`

Convention plugin count 19 → 20 in all three places it appears. `wiki/07` is now 20 findings.

`wiki/00` had an entry under "Opinions the code does *not* enforce" reading "Feature-to-feature isolation is unchecked. The boundary task inspects `:app` only, so one feature importing another compiles happily." That was outright wrong after #26, and wrong in the most misleading direction — telling a reader a guardrail is absent when it will fail their build. Replaced with what is genuinely still unenforced: build-file coupling, removability being proven for only four modules, and the unprotected `main`.

`wiki/01` gains the 44-library-module figure, since that is the set the check covers and it is not the same as the 47-module inventory.

## `wiki/08`

Adds `:core:data:checkModuleBoundary` and `:feature:auth:presentation:checkModuleBoundary` next to the existing app command, plus the escape hatch in the "Removing what you do not need" section. Records that `ktlintCheck` does **not** trigger `preBuild`, so a lint-only run will not surface a violation — a genuine surprise if you are trying to reproduce a red pipeline locally.

## `build-logic/README.md`

Documents `composetemplate.module.boundary`, notes that `composetemplate.android.library` applies it, and updates the file tree (`CheckAppModuleBoundaryTask.kt` is gone; `CheckModuleBoundaryTask.kt` and `ModuleBoundaryPlugin.kt` are new).

Also fixes `~48 modules`, which has been 47 since module discovery landed. Small, but it is the kind of number a reader trusts precisely because nobody would bother to fake it.

## What is not here

- **`last-updated` / version stamps.** Automating them needs `fetch-depth: 0` in `pages.yml`, which needs workflow write. Content freshness first.
- **A docs-freshness CI assertion.** Same reason.
- The remaining `wiki/07` items awaiting a decision rather than an edit: reprioritizing finding 4 (pick one serialization stack), reframing finding 1, and raising finding 9.

## Verification

CI on a docs-only change produces a cache-heavy green run that verifies nothing about the documents themselves. The claim worth checking is that the rule table, task names, report paths and the escape-hatch snippet match `ModuleBoundaryPlugin.kt` and `CheckModuleBoundaryTask.kt` as merged — every one of them was copied from the source on `main`, not from the PR description of #26.

`mkdocs build --strict` is not a pull-request check (finding 19), so the internal links added here — the `#baseline-decision-log` anchor in particular — are unverified until the site rebuilds after merge.